### PR TITLE
Remove STM, not ERC20

### DIFF
--- a/tokens/0xdf1ce35938f9ca2eab682284f82a81a9d25665ce.yaml
+++ b/tokens/0xdf1ce35938f9ca2eab682284f82a81a9d25665ce.yaml
@@ -1,9 +1,0 @@
----
-addr: '0xdf1ce35938f9ca2eab682284f82a81a9d25665ce'
-decimals: 2
-description: >-
-  Industrial mining farms in Russia and Europe
-links:
-- Website: http://startmining.com/en
-name: Start mining
-symbol: STM


### PR DESCRIPTION
STM is 0xdf1ce35938f9ca2eab682284f82a81a9d25665ce.

The contract is reporting `tokenSupply = 0` and does not appear to conform to ERC20.