### PR TITLE
Add Populous XBRL token (PXBRL aka PXT)

### DIFF
--- a/tokens/0xc14830e53aa344e8c14603a91229a0b925b0b262.yaml
+++ b/tokens/0xc14830e53aa344e8c14603a91229a0b925b0b262.yaml
@@ -1,0 +1,27 @@
+---
+__FORKDELTA_CUSTOM_SYMBOL: PXBRL
+addr: '0xc14830e53aa344e8c14603a91229a0b925b0b262'
+decimals: 8
+description: >-
+  The PXT Token is going to be used for that exact value exchange. Monetzing data.
+
+  The Populous ecosystem will be able to provide existing financial systems incredible
+  value on the transfer of data and micro-services that we see companies paying a
+  huge premium for at the moment.
+
+  Companies will have to use said PXT Token in order for them to take advantage
+  of things such as Credit reports and Analysis, or to fully utilise our API.
+links:
+- Bitcointalk: https://bitcointalk.org/index.php?topic=1866936.0
+- Blog: https://medium.com/bitpopulous/
+- Email: mailto:steve@populous.co
+- Github: https://github.com/bitpopulous
+- Linkedin: https://www.linkedin.com/company/9254295/
+- Reddit: https://www.reddit.com/r/populous_platform/
+- Slack: https://bitpopulous.slack.com/
+- Telegram: https://t.me/ppttalk
+- Twitter: https://twitter.com/bitpopulous
+- Website: https://populous.co/
+- Whitepaper: https://populous.co/populous_whitepaper.pdf
+name: Populous XBRL token
+symbol: PXT


### PR DESCRIPTION
Populous XBRL token (PXBRL aka PXT) is:

* https://etherscan.io/token/0xc14830e53aa344e8c14603a91229a0b925b0b262
* A new token from Populous: https://twitter.com/BitPopulous/status/947465562552184832
* Airdropped to existing PPT holders on Dec 31, 2017
* Currently has 9001 holders
* 9462 transactions

Token will be named as PXBRL on ForkDelta due to a symbol conflict.

Closes #28.