### PR TITLE
Enable no-response bot

### DIFF
--- a/.github/no-response.yml
+++ b/.github/no-response.yml
@@ -1,0 +1,13 @@
+# Configuration for probot-no-response - https://github.com/probot/no-response
+
+# Number of days of inactivity before an Issue is closed for lack of response
+daysUntilClose: 10
+# Label requiring a response
+responseRequiredLabel: missing information
+# Comment to post when closing an Issue for lack of response. Set to `false` to disable
+closeComment: >
+  This issue has been automatically closed because there has been no response
+  to our request for more information from the original author. With only the
+  information that is currently in the issue, we don't have enough information
+  to take action. Please reach out if you have or find the answers we need so
+  that we can investigate further.


### PR DESCRIPTION
This PR adds a configuration file for probot/no-response bot: if an issue has a "missing information" label and receives no response from the poster in 10 days, it will be closed, and the `closeComment` will be posted.

@Kryptoniq @tradedbytony This should hopefully help us clean stale issues up.