### PR TITLE
List EGG EGG Token

### DIFF
--- a/tokens/0x7c47318dd2d79976032951f535cb5a713bd53971.yaml
+++ b/tokens/0x7c47318dd2d79976032951f535cb5a713bd53971.yaml
@@ -1,0 +1,13 @@
+---
+addr: '0x7c47318dd2d79976032951f535cb5a713bd53971'
+decimals: 18
+description: Thisorthat.io is a marketing DApp where users answer questions to win tokens!  
+links:
+- Email: mailto:info@freerangespaces.com
+- Telegram: https://t.me/freeRangeico
+- Twitter: https://twitter.com/freerangespaces
+- Website: https://thisorthat.io/
+- Whitepaper: https://startengine.com/frtoken
+name: EGGtoken
+symbol: EGG
+---


### PR DESCRIPTION
3rd party links:

[https://www.bizjournals.com/albuquerque/news/2018/04/18/four-new-mexico-startups-invited-to-summit-in.html](https://www.bizjournals.com/albuquerque/news/2018/04/18/four-new-mexico-startups-invited-to-summit-in.html)

[https://youtu.be/WWjeKXTFs8g](https://youtu.be/WWjeKXTFs8g)

We beat cryptokitties in DAU on Dappradar.com on May 7th, now relaunching with erc20 compatibility. Proof of concept is using EGGtokens. Advertisers will need to purchase EGG on exchanges to use the platform.

![DApp Radar](https://user-images.githubusercontent.com/35241800/40273323-7a7cbd4e-5b7b-11e8-8721-4152c480732a.png)

Note: We are not selling our utility token directly. Rather we are raising funds by selling an equity backed security named CHKNtoken. Current EGGtoken distribution is through the DApp. Details found on https://StartEngine.com/FRtoken