### PR TITLE
Replace CoinMarketCap slugs with proper canonical URLs

### DIFF
--- a/tokens/0x006bea43baa3f7a6f765f14f10a1a1b08334ef45.yaml
+++ b/tokens/0x006bea43baa3f7a6f765f14f10a1a1b08334ef45.yaml
@@ -6,7 +6,7 @@ description: >-
   day people will be able to predict and trade the outcome of events in almost any imaginable category:
   Finance, sports, politics and even the weather.
 links:
-- CoinMarketCap: stox
+- CoinMarketCap: https://coinmarketcap.com/currencies/stox/
 - Github: https://github.com/stx-technologies/stox-token
 - Reddit: https://www.reddit.com/r/STOX/
 - Telegram: https://t.me/joinchat/DByWw0Pnq9BAy4FqPv_Lyg

--- a/tokens/0x0371a82e4a9d0a4312f3ee2ac9c6958512891372.yaml
+++ b/tokens/0x0371a82e4a9d0a4312f3ee2ac9c6958512891372.yaml
@@ -6,7 +6,7 @@ description: >-
 links:
 - Bitcointalk: https://bitcointalk.org/index.php?topic=1980078.msg19714383#msg19714383
 - Blog: https://medium.com/bitjob
-- CoinMarketCap: student-coin
+- CoinMarketCap: https://coinmarketcap.com/currencies/student-coin/
 - Email: mailto:Info@bitjob.io
 - Facebook: https://www.facebook.com/bitJobmarket/
 - Github: https://github.com/bitjobteam

--- a/tokens/0x05c7065d644096a4e4c3fe24af86e36de021074b.yaml
+++ b/tokens/0x05c7065d644096a4e4c3fe24af86e36de021074b.yaml
@@ -6,7 +6,7 @@ description: >-
   sense. But we are not just "another" lending platform among all the other platforms. We are the one
   that combines the possibilities of the crypto lending platforms into one.
 links:
-- CoinMarketCap: lendconnect
+- CoinMarketCap: https://coinmarketcap.com/currencies/lendconnect/
 - Email: mailto:info@lendconnect.io
 - Telegram: https://t.me/joinchat/AAAAAE1W8wql5nyoOFx4QQ
 - Website: https://lendconnect.io/

--- a/tokens/0x06147110022b768ba8f99a8f385df11a151a9cc8.yaml
+++ b/tokens/0x06147110022b768ba8f99a8f385df11a151a9cc8.yaml
@@ -7,7 +7,7 @@ description: >-
 links:
 - Bitcointalk: https://bitcointalk.org/index.php?topic=2043613.0
 - Blog: https://medium.com/@tokenstars
-- CoinMarketCap: ace
+- CoinMarketCap: https://coinmarketcap.com/currencies/ace/
 - Email: mailto:tokenstars@tokenstars.com
 - Facebook: https://www.facebook.com/TokenStars/
 - Github: https://github.com/token-stars

--- a/tokens/0x07d9e49ea402194bf48a8276dafb16e4ed633317.yaml
+++ b/tokens/0x07d9e49ea402194bf48a8276dafb16e4ed633317.yaml
@@ -6,7 +6,7 @@ description: >-
   many as possible on how  crypto currency trading and investing can be used to improve their finances.
 links:
 - Bitcointalk: https://bitcointalk.org/index.php?topic=2057829.0
-- CoinMarketCap: dalecoin
+- CoinMarketCap: https://coinmarketcap.com/currencies/dalecoin/
 - Email: mailto:support@dalecoin.org
 - Facebook: https://www.facebook.com/dalecoin/
 - Telegram: https://t.me/dalecoin

--- a/tokens/0x07e3c70653548b04f0a75970c1f81b4cbbfb606f.yaml
+++ b/tokens/0x07e3c70653548b04f0a75970c1f81b4cbbfb606f.yaml
@@ -6,7 +6,7 @@ description: >-
   on the blockchain. No coding or legal skills required.
 links:
 - Blog: https://blog.agrello.org/
-- CoinMarketCap: agrello-delta
+- CoinMarketCap: https://coinmarketcap.com/currencies/agrello-delta/
 - Email: mailto:info@agrello.org
 - Facebook: https://www.facebook.com/agrellofoundation/
 - Reddit: https://www.reddit.com/r/Agrello/

--- a/tokens/0x08711d3b02c8758f2fb3ab4e80228418a7f8e39c.yaml
+++ b/tokens/0x08711d3b02c8758f2fb3ab4e80228418a7f8e39c.yaml
@@ -7,7 +7,7 @@ description: >-
 links:
 - Bitcointalk: https://bitcointalk.org/index.php?topic=1718384.0
 - Blog: https://medium.com/Edgeless
-- CoinMarketCap: edgeless
+- CoinMarketCap: https://coinmarketcap.com/currencies/edgeless/
 - Email: mailto:support@edgeless.io
 - Facebook: https://www.facebook.com/EdgelessCasino/?fref=ts
 - Github: https://github.com/EdgelessCasino

--- a/tokens/0x08d32b0da63e2c3bcf8019c9c5d849d7a9d791e6.yaml
+++ b/tokens/0x08d32b0da63e2c3bcf8019c9c5d849d7a9d791e6.yaml
@@ -42,7 +42,7 @@ description: >-
 links:
 - Bitcointalk: https://bitcointalk.org/index.php?topic=1944236.0
 - Blog: https://www.dentacoin.com/blog/
-- CoinMarketCap: dentacoin
+- CoinMarketCap: https://coinmarketcap.com/currencies/dentacoin/
 - Email: mailto:admin@dentacoin.com
 - Facebook: https://www.facebook.com/dentacoin/
 - Github: https://github.com/Dentacoin

--- a/tokens/0x08f5a9235b08173b7569f83645d2c7fb55e8ccd8.yaml
+++ b/tokens/0x08f5a9235b08173b7569f83645d2c7fb55e8ccd8.yaml
@@ -6,7 +6,7 @@ description: >-
 links:
 - Bitcointalk: https://bitcointalk.org/index.php?topic=2027510.0
 - Blog: https://medium.com/@WayneVaughan
-- CoinMarketCap: tierion
+- CoinMarketCap: https://coinmarketcap.com/currencies/tierion/
 - Email: mailto:tokensale@tierion.com
 - Facebook: https://www.facebook.com/TierionInc/
 - Github: https://github.com/Tierion

--- a/tokens/0x0abdace70d3790235af448c88547603b945604ea.yaml
+++ b/tokens/0x0abdace70d3790235af448c88547603b945604ea.yaml
@@ -6,7 +6,7 @@ description: >-
   Aragon, and IPFS.
 links:
 - Blog: https://blog.district0x.io/
-- CoinMarketCap: district0x
+- CoinMarketCap: https://coinmarketcap.com/currencies/district0x/
 - Email: mailto:hello@district0x.io
 - Github: https://github.com/district0x
 - Slack: https://district0x-slack.herokuapp.com/

--- a/tokens/0x0af44e2784637218dd1d32a322d44e603a8f0c6a.yaml
+++ b/tokens/0x0af44e2784637218dd1d32a322d44e603a8f0c6a.yaml
@@ -6,7 +6,7 @@ description: >-
   fairly, R&amp;D expenses are reduced and time is saved.
 links:
 - Blog: https://blog.matryx.ai/
-- CoinMarketCap: matryx
+- CoinMarketCap: https://coinmarketcap.com/currencies/matryx/
 - Email: mailto:team@matryx.ai
 - Facebook: https://www.facebook.com/matryxai/
 - Reddit: https://www.reddit.com/r/matryx/

--- a/tokens/0x0affa06e7fbe5bc9a764c979aa66e8256a631f02.yaml
+++ b/tokens/0x0affa06e7fbe5bc9a764c979aa66e8256a631f02.yaml
@@ -4,7 +4,7 @@ decimals: 6
 description: >-
   Polybius is a project aimed to create a regulated bank for the digital generation.
 links:
-- CoinMarketCap: Polybius
+- CoinMarketCap: https://coinmarketcap.com/currencies/Polybius/
 - Email: mailto:info@polybius.io
 - Facebook: https://www.facebook.com/projectpolybius/
 - Telegram: https://t.me/polybius_eng

--- a/tokens/0x0b1724cc9fda0186911ef6a75949e9c0d3f0f2f3.yaml
+++ b/tokens/0x0b1724cc9fda0186911ef6a75949e9c0d3f0f2f3.yaml
@@ -5,7 +5,7 @@ description: >-
   ETHERIYA: AN Ethereum Token Backed Micro & Macro Freelance Marketplace
 links:
 - Bitcointalk: https://bitcointalk.org/index.php?topic=1975694.0
-- CoinMarketCap: etheriya
+- CoinMarketCap: https://coinmarketcap.com/currencies/etheriya/
 - Email: mailto:etheriyaproject@gmail.com
 - Website: http://www.etheriya.net/
 - Whitepaper: https://drive.google.com/file/d/0B9nA1PpRUjmuTG4ySFUzQXhwUkU/view

--- a/tokens/0x0cf0ee63788a0849fe5297f3407f701e122cc023.yaml
+++ b/tokens/0x0cf0ee63788a0849fe5297f3407f701e122cc023.yaml
@@ -8,7 +8,7 @@ description: >-
   controlled by no one and incentivized by the DATAcoin token.
 links:
 - Blog: https://blog.streamr.com/
-- CoinMarketCap: streamr-datacoin
+- CoinMarketCap: https://coinmarketcap.com/currencies/streamr-datacoin/
 - Email: mailto:contact@streamr.com
 - Github: https://github.com/streamr-dev
 - Slack: https://slack.streamr.com/

--- a/tokens/0x0d8775f648430679a709e98d2b0cb6250d2887ef.yaml
+++ b/tokens/0x0d8775f648430679a709e98d2b0cb6250d2887ef.yaml
@@ -13,7 +13,7 @@ description: >-
   The utility of the token is based on user attention, which simply means a person&rsquo;s focused mental
   engagement.
 links:
-- CoinMarketCap: basic-attention-token
+- CoinMarketCap: https://coinmarketcap.com/currencies/basic-attention-token/
 - Email: mailto:https://medium.com/@attentiontoken
 - Reddit: https://www.reddit.com/r/BATProject/
 - Twitter: https://twitter.com/@attentiontoken

--- a/tokens/0x0d88ed6e74bbfd96b831231638b66c05571e824f.yaml
+++ b/tokens/0x0d88ed6e74bbfd96b831231638b66c05571e824f.yaml
@@ -6,7 +6,7 @@ description: >-
 links:
 - Bitcointalk: https://bitcointalk.org/index.php?topic=2047321.0
 - Blog: https://medium.com/aventus
-- CoinMarketCap: aventus
+- CoinMarketCap: https://coinmarketcap.com/currencies/aventus/
 - Github: https://github.com/AventusSystems
 - Reddit: https://www.reddit.com/r/Aventus/
 - Slack: https://slack.aventus.io/

--- a/tokens/0x0e0989b1f9b8a38983c2ba8053269ca62ec9b195.yaml
+++ b/tokens/0x0e0989b1f9b8a38983c2ba8053269ca62ec9b195.yaml
@@ -9,7 +9,7 @@ description: >-
 links:
 - Bitcointalk: https://bitcointalk.org/index.php?topic=2027214.0
 - Blog: https://blog.po.et/
-- CoinMarketCap: poet
+- CoinMarketCap: https://coinmarketcap.com/currencies/poet/
 - Email: mailto:contact@po.et
 - Reddit: https://www.reddit.com/r/poetproject/
 - Slack: https://poet-slack.herokuapp.com/

--- a/tokens/0x0f4ca92660efad97a9a70cb0fe969c755439772c.yaml
+++ b/tokens/0x0f4ca92660efad97a9a70cb0fe969c755439772c.yaml
@@ -10,7 +10,7 @@ description: >-
 links:
 - Bitcointalk: https://bitcointalk.org/index.php?topic=2258761.0
 - Blog: https://blog.leverj.io/
-- CoinMarketCap: leverj
+- CoinMarketCap: https://coinmarketcap.com/currencies/leverj/
 - Email: mailto:info@leverj.io
 - Facebook: https://www.facebook.com/leverj.io/
 - Github: https://github.com/leverj

--- a/tokens/0x0f5d2fb29fb7d3cfee444a200298f468908cc942.yaml
+++ b/tokens/0x0f5d2fb29fb7d3cfee444a200298f468908cc942.yaml
@@ -6,7 +6,7 @@ description: >-
   and monetize content and applications.
 links:
 - Blog: https://blog.decentraland.org/
-- CoinMarketCap: decentraland
+- CoinMarketCap: https://coinmarketcap.com/currencies/decentraland/
 - Email: mailto:hello@decentraland.org
 - Facebook: https://www.facebook.com/decentraland/
 - Github: https://github.com/decentraland

--- a/tokens/0x103c3a209da59d3e7c4a89307e66521e081cfdf0.yaml
+++ b/tokens/0x103c3a209da59d3e7c4a89307e66521e081cfdf0.yaml
@@ -8,7 +8,7 @@ description: >-
 links:
 - Bitcointalk: https://bitcointalk.org/index.php?topic=2143279.0
 - Blog: https://medium.com/genesisvision/
-- CoinMarketCap: genesis-vision
+- CoinMarketCap: https://coinmarketcap.com/currencies/genesis-vision/
 - Email: mailto:support@genesis.vision
 - Facebook: https://www.facebook.com/GenesisVisionProject
 - Github: https://github.com/GenesisVision

--- a/tokens/0x107c4504cd79c5d2696ea0030a8dd4e92601b82e.yaml
+++ b/tokens/0x107c4504cd79c5d2696ea0030a8dd4e92601b82e.yaml
@@ -7,7 +7,7 @@ description: >-
   who currently cannot obtain a bank account or credit score.
 links:
 - Blog: https://blog.hellobloom.io/
-- CoinMarketCap: bloomtoken
+- CoinMarketCap: https://coinmarketcap.com/currencies/bloomtoken/
 - Email: mailto:team@hellobloom.io
 - Facebook: https://www.facebook.com/bloomtoken/
 - Github: https://github.com/hellobloom

--- a/tokens/0x1183f92a5624d68e85ffb9170f16bf0443b4c242.yaml
+++ b/tokens/0x1183f92a5624d68e85ffb9170f16bf0443b4c242.yaml
@@ -6,7 +6,7 @@ description: >-
 links:
 - Bitcointalk: https://bitcointalk.org/index.php?topic=2018731.msg20116760#msg20116760
 - Blog: https://medium.com/@Qvolta
-- CoinMarketCap: qvolta
+- CoinMarketCap: https://coinmarketcap.com/currencies/qvolta/
 - Email: mailto:hello@qvolta.com
 - Facebook: https://www.facebook.com/qvolta/
 - Github: https://github.com/qvolta

--- a/tokens/0x1245ef80f4d9e02ed9425375e8f649b9221b31d8.yaml
+++ b/tokens/0x1245ef80f4d9e02ed9425375e8f649b9221b31d8.yaml
@@ -5,7 +5,7 @@ description: >-
   TRADING CRYPTO-CURRENCY TERMINAL FOR TRADING ON TWO EXCHANGES SIMULTANEOUSLY!
 links:
 - Bitcointalk: https://bitcointalk.org/index.php?topic=2242346
-- CoinMarketCap: arbitragect
+- CoinMarketCap: https://coinmarketcap.com/currencies/arbitragect/
 - Email: mailto:kirill@arbitragect.com
 - Facebook: https://www.facebook.com/groups/arbitragect/
 - Reddit: https://www.reddit.com/r/arbitrageCT/

--- a/tokens/0x12480e24eb5bec1a9d4369cab6a80cad3c0a377a.yaml
+++ b/tokens/0x12480e24eb5bec1a9d4369cab6a80cad3c0a377a.yaml
@@ -14,7 +14,7 @@ description: >-
   technology and artificial intelligence.
 links:
 - Blog: http://substratum.net/blog
-- CoinMarketCap: substratum
+- CoinMarketCap: https://coinmarketcap.com/currencies/substratum/
 - Email: mailto:justin@substratum.net
 - Reddit: https://www.reddit.com/r/SubstratumNetwork/
 - Slack: https://substratumcoin.slack.com/join/shared_invite/MjI3Nzc5NzExNDg4LTE1MDMwNDY5ODItODlkYjNiYzhkZg

--- a/tokens/0x12b19d3e2ccc14da04fae33e63652ce469b3f2fd.yaml
+++ b/tokens/0x12b19d3e2ccc14da04fae33e63652ce469b3f2fd.yaml
@@ -5,7 +5,7 @@ description: >-
   Welcome to the Future of Energy
 links:
 - Blog: https://blog.gridplus.io/
-- CoinMarketCap: grid
+- CoinMarketCap: https://coinmarketcap.com/currencies/grid/
 - Github: https://github.com/gridplus
 - Slack: https://grid-plus.slack.com/
 - Twitter: https://twitter.com/gridplus_energy

--- a/tokens/0x12b306fa98f4cbb8d4457fdff3a0a0a56f07ccdf.yaml
+++ b/tokens/0x12b306fa98f4cbb8d4457fdff3a0a0a56f07ccdf.yaml
@@ -8,7 +8,7 @@ description: >-
 links:
 - Bitcointalk: https://bitcointalk.org/index.php?topic=2169122.0
 - Blog: https://medium.com/teamspectreai
-- CoinMarketCap: spectre-dividend
+- CoinMarketCap: https://coinmarketcap.com/currencies/spectre-dividend/
 - Email: mailto:team@spectre.ai
 - Facebook: https://www.facebook.com/spectrepage/
 - Github: https://github.com/spectre-ai

--- a/tokens/0x12fef5e57bf45873cd9b62e9dbd7bfb99e32d73e.yaml
+++ b/tokens/0x12fef5e57bf45873cd9b62e9dbd7bfb99e32d73e.yaml
@@ -7,7 +7,7 @@ description: >-
   then for the whole world.
 links:
 - Blog: https://blog.cofound.it/
-- CoinMarketCap: cofound-it
+- CoinMarketCap: https://coinmarketcap.com/currencies/cofound-it/
 - Email: mailto:info@cofound.it
 - Facebook: https://www.facebook.com/CofounditEcosystem/
 - Reddit: https://www.reddit.com/r/cofoundit/

--- a/tokens/0x138a8752093f4f9a79aaedf48d4b9248fab93c9c.yaml
+++ b/tokens/0x138a8752093f4f9a79aaedf48d4b9248fab93c9c.yaml
@@ -5,7 +5,7 @@ description: >-
   Introducing MUSICONOMI - A Global Music Economy That Works for Everyone.
 links:
 - Blog: https://medium.com/musiconomi
-- CoinMarketCap: musiconomi
+- CoinMarketCap: https://coinmarketcap.com/currencies/musiconomi/
 - Email: mailto:musiconomi@musiconomi.com
 - Facebook: https://www.facebook.com/Musiconomi/
 - Github: https://github.com/musiconomi/

--- a/tokens/0x13f1b7fdfbe1fc66676d56483e21b1ecb40b58e2.yaml
+++ b/tokens/0x13f1b7fdfbe1fc66676d56483e21b1ecb40b58e2.yaml
@@ -6,7 +6,7 @@ description: >-
   smart contract on Ethereum. The Accelerator Token allows holders to mine more Accelerator Tokens at
   pre-defined rate. Then, spend them for services offered by the Accelerator Network.
 links:
-- CoinMarketCap: accelerator-network
+- CoinMarketCap: https://coinmarketcap.com/currencies/accelerator-network/
 - Email: mailto:help@accelerator.network
 - Github: https://github.com/acceleratornetwork/accelerator-token
 - Slack: http://slack.accelerator.network/

--- a/tokens/0x14839bf22810f09fb163af69bd21bd5476f445cd.yaml
+++ b/tokens/0x14839bf22810f09fb163af69bd21bd5476f445cd.yaml
@@ -5,7 +5,7 @@ description: >-
   A trustless escrow payment solution using smart contracts with a unique shipping tracking feature.
 links:
 - Blog: https://medium.com/@Confido.io
-- CoinMarketCap: confido
+- CoinMarketCap: https://coinmarketcap.com/currencies/confido/
 - Email: mailto:info@confido.io
 - Facebook: https://www.facebook.com/confido.io/
 - Reddit: https://www.reddit.com/r/confido/

--- a/tokens/0x14f37b574242d366558db61f3335289a5035c506.yaml
+++ b/tokens/0x14f37b574242d366558db61f3335289a5035c506.yaml
@@ -6,7 +6,7 @@ description: >-
   can release their own token which can only be exchanged for HKG. This allows camps to be financed and
   the community to support innovative projects.
 links:
-- CoinMarketCap: hacker-gold
+- CoinMarketCap: https://coinmarketcap.com/currencies/hacker-gold/
 - Email: mailto:contact@ether.camp
 - Facebook: https://www.facebook.com/hack.ether.camp
 - Twitter: https://twitter.com/CampEther

--- a/tokens/0x15f173b7aca7cd4a01d6f8360e65fb4491d270c1.yaml
+++ b/tokens/0x15f173b7aca7cd4a01d6f8360e65fb4491d270c1.yaml
@@ -15,7 +15,7 @@ description: >-
   we'll prevail.
 links:
 - Bitcointalk: https://bitcointalk.org/index.php?topic=2257727
-- CoinMarketCap: ereal
+- CoinMarketCap: https://coinmarketcap.com/currencies/ereal/
 - Email: mailto:satoshi@ereal.cash
 - Facebook: https://www.facebook.com/groups/ereal/about/
 - Telegram: https://t.me/joinchat/GACY40JExuZ2WdgGTwD6YQ

--- a/tokens/0x168296bb09e24a88805cb9c33356536b980d3fc5.yaml
+++ b/tokens/0x168296bb09e24a88805cb9c33356536b980d3fc5.yaml
@@ -5,7 +5,7 @@ description: >-
   The RHOC token is an RChain.coop promotional token redeemable for the actual RChain token when the network
   is launched.
 links:
-- CoinMarketCap: rchain
+- CoinMarketCap: https://coinmarketcap.com/currencies/rchain/
 - Github: https://github.com/rchain/
 - Slack: http://slack.rchain.coop/
 - Twitter: https://twitter.com/rchain_coop/

--- a/tokens/0x1776e1f26f98b1a5df9cd347953a26dd3cb46671.yaml
+++ b/tokens/0x1776e1f26f98b1a5df9cd347953a26dd3cb46671.yaml
@@ -5,7 +5,7 @@ description: >-
   Numerai is new kind of hedge fund built by a network of data scientists.
 links:
 - Blog: https://medium.com/@Numerai
-- CoinMarketCap: numeraire
+- CoinMarketCap: https://coinmarketcap.com/currencies/numeraire/
 - Email: mailto:contact@numer.ai
 - Slack: https://slack.numer.ai/
 - Website: https://numer.ai/

--- a/tokens/0x177d39ac676ed1c67a2b268ad7f1e58826e5b0af.yaml
+++ b/tokens/0x177d39ac676ed1c67a2b268ad7f1e58826e5b0af.yaml
@@ -7,7 +7,7 @@ description: >-
   accessible to everyone. CoinDash will offer its products through a unified platform designed with the
   mainstream user in mind.
 links:
-- CoinMarketCap: coindash
+- CoinMarketCap: https://coinmarketcap.com/currencies/coindash/
 - Email: mailto:contact@coindash.io
 - Facebook: https://www.facebook.com/coindash.io/
 - Slack: https://coindasher-slack.herokuapp.com/

--- a/tokens/0x1844b21593262668b7248d0f57a220caaba46ab9.yaml
+++ b/tokens/0x1844b21593262668b7248d0f57a220caaba46ab9.yaml
@@ -14,7 +14,7 @@ description: >-
   their embedded state, therefore guaranteeing the data's integrity for the correct amount of time.
 links:
 - Blog: https://medium.com/oysterprotocol
-- CoinMarketCap: oyster-pearl
+- CoinMarketCap: https://coinmarketcap.com/currencies/oyster-pearl/
 - Email: mailto:contact@oyster.ws
 - Github: https://github.com/oysterprotocol
 - Telegram: https://t.me/oysterprotocol

--- a/tokens/0x1961b3331969ed52770751fc718ef530838b6dee.yaml
+++ b/tokens/0x1961b3331969ed52770751fc718ef530838b6dee.yaml
@@ -8,7 +8,7 @@ description: >-
 links:
 - Bitcointalk: https://bitcointalk.org/index.php?topic=2214321
 - Blog: https://blog.bitdegree.org/
-- CoinMarketCap: bitdegree
+- CoinMarketCap: https://coinmarketcap.com/currencies/bitdegree/
 - Email: mailto:hello@bitdegree.org
 - Facebook: https://www.facebook.com/bitdegree.org/
 - Github: https://github.com/bitdegree

--- a/tokens/0x1b22c32cd936cb97c28c5690a0695a82abf688e6.yaml
+++ b/tokens/0x1b22c32cd936cb97c28c5690a0695a82abf688e6.yaml
@@ -7,7 +7,7 @@ description: >-
 links:
 - Bitcointalk: https://bitcointalk.org/index.php?topic=2059189.msg20545654#msg20545654
 - Blog: https://medium.com/@VladimirTikhomirov
-- CoinMarketCap: mywish
+- CoinMarketCap: https://coinmarketcap.com/currencies/mywish/
 - Email: mailto:support@mywish.io
 - Facebook: https://www.facebook.com/MyWish.io/
 - Github: https://github.com/mywishplatform

--- a/tokens/0x1b9743f556d65e757c4c650b4555baf354cb8bd3.yaml
+++ b/tokens/0x1b9743f556d65e757c4c650b4555baf354cb8bd3.yaml
@@ -7,7 +7,7 @@ description: >-
   Get Ether and Bitcoin simply and safely.
 links:
 - Bitcointalk: https://bitcointalk.org/index.php?topic=1852294
-- CoinMarketCap: ethbits
+- CoinMarketCap: https://coinmarketcap.com/currencies/ethbits/
 - Email: mailto:mr@ethbits.com
 - Reddit: https://www.reddit.com/r/Ethbits/
 - Slack: https://ethbits.slack.com/

--- a/tokens/0x1bcbc54166f6ba149934870b60506199b6c9db6d.yaml
+++ b/tokens/0x1bcbc54166f6ba149934870b60506199b6c9db6d.yaml
@@ -21,7 +21,7 @@ description: >-
   inside in an immersive way all from their own home.
 links:
 - Bitcointalk: https://bitcointalk.org/index.php?topic=2048747
-- CoinMarketCap: rasputin-online-coin
+- CoinMarketCap: https://coinmarketcap.com/currencies/rasputin-online-coin/
 - Email: mailto:hello@rasputinonline.com
 - Facebook: https://www.facebook.com/rasputinonline/
 - Github: https://github.com/Rasputinonline/ROC

--- a/tokens/0x1c4481750daa5ff521a2a7490d9981ed46465dbd.yaml
+++ b/tokens/0x1c4481750daa5ff521a2a7490d9981ed46465dbd.yaml
@@ -6,7 +6,7 @@ description: >-
 links:
 - Bitcointalk: https://bitcointalk.org/index.php?topic=2129993
 - Blog: https://medium.com/@blockmason
-- CoinMarketCap: blockmason
+- CoinMarketCap: https://coinmarketcap.com/currencies/blockmason/
 - Email: mailto:info@blockmason.io
 - Facebook: https://www.facebook.com/blockmasonio/
 - Github: https://github.com/blockmason

--- a/tokens/0x1d462414fe14cf489c7a21cac78509f4bf8cd7c0.yaml
+++ b/tokens/0x1d462414fe14cf489c7a21cac78509f4bf8cd7c0.yaml
@@ -6,7 +6,7 @@ description: >-
   providers.
 links:
 - Blog: https://blog.canya.com.au/
-- CoinMarketCap: canyacoin
+- CoinMarketCap: https://coinmarketcap.com/currencies/canyacoin/
 - Email: mailto:support@canya.com.au
 - Facebook: https://www.facebook.com/CanYaapp/
 - Github: https://github.com/CanYaCoinSale/

--- a/tokens/0x1f573d6fb3f13d689ff844b4ce37794d79a7ff1c.yaml
+++ b/tokens/0x1f573d6fb3f13d689ff844b4ce37794d79a7ff1c.yaml
@@ -6,7 +6,7 @@ description: >-
 links:
 - Bitcointalk: https://bitcointalk.org/index.php?topic=1789222.0
 - Blog: https://blog.bancor.network/
-- CoinMarketCap: bancor
+- CoinMarketCap: https://coinmarketcap.com/currencies/bancor/
 - Email: https://bancor.network/contact
 - Reddit: https://www.reddit.com/r/Bancor/
 - Slack: https://bancor-slack-invite.herokuapp.com/

--- a/tokens/0x219218f117dc9348b358b8471c55a073e5e0da0b.yaml
+++ b/tokens/0x219218f117dc9348b358b8471c55a073e5e0da0b.yaml
@@ -11,7 +11,7 @@ description: >-
   like travel, games, sports, health etc. Comprehensive details about Gold Reward Token can be found in
   the white paper.
 links:
-- CoinMarketCap: gold-reward-token
+- CoinMarketCap: https://coinmarketcap.com/currencies/gold-reward-token/
 - Email: mailto:support@goldreward.io
 - Facebook: https://www.facebook.com/Goldreward/
 - Telegram: https://t.me/joinchat/AAAAAEH3O3kOexOTBEuZFg

--- a/tokens/0x2233799ee2683d75dfefacbcd2a26c78d34b470d.yaml
+++ b/tokens/0x2233799ee2683d75dfefacbcd2a26c78d34b470d.yaml
@@ -12,7 +12,7 @@ description: >-
   on board with crypto.
 links:
 - Bitcointalk: https://bitcointalk.org/index.php?topic=2343147
-- CoinMarketCap: network-token
+- CoinMarketCap: https://coinmarketcap.com/currencies/network-token/
 - Email: mailto:hello@networktoken.io
 - Facebook: https://www.facebook.com/networktoken/
 - Telegram: https://t.me/networktoken

--- a/tokens/0x226bb599a12c826476e3a771454697ea52e9e220.yaml
+++ b/tokens/0x226bb599a12c826476e3a771454697ea52e9e220.yaml
@@ -6,7 +6,7 @@ description: >-
 links:
 - Bitcointalk: https://bitcointalk.org/index.php?topic=1982115
 - Blog: https://medium.com/@propy
-- CoinMarketCap: propy
+- CoinMarketCap: https://coinmarketcap.com/currencies/propy/
 - Email: mailto:ico@propy.com
 - Facebook: https://www.facebook.com/propyinc
 - Reddit: https://www.reddit.com/user/PropyInc/

--- a/tokens/0x24692791bc444c5cd0b81e3cbcaba4b04acd1f3b.yaml
+++ b/tokens/0x24692791bc444c5cd0b81e3cbcaba4b04acd1f3b.yaml
@@ -9,7 +9,7 @@ description: >-
 links:
 - Bitcointalk: https://bitcointalk.org/index.php?topic=2206150.40
 - Blog: https://news.unikrn.com/topic/UnikoinGold
-- CoinMarketCap: unikoin-gold
+- CoinMarketCap: https://coinmarketcap.com/currencies/unikoin-gold/
 - Email: mailto:support@unikoingold.com
 - Facebook: https://www.facebook.com/UnikoinGold/
 - Github: https://github.com/unikoingold/

--- a/tokens/0x255aa6df07540cb5d3d297f0d0d4d84cb52bc8e6.yaml
+++ b/tokens/0x255aa6df07540cb5d3d297f0d0d4d84cb52bc8e6.yaml
@@ -7,7 +7,7 @@ description: >-
   project is work in progress. Its goal is to research state channel technology, define protocols and
   develop reference implementations.
 links:
-- CoinMarketCap: raiden-network-token
+- CoinMarketCap: https://coinmarketcap.com/currencies/raiden-network-token/
 - Email: mailto:contact@raiden.network
 - Github: https://github.com/raiden-network/raiden/
 - Reddit: https://www.reddit.com/r/raidennetwork/

--- a/tokens/0x2604fa406be957e542beb89e6754fcde6815e83f.yaml
+++ b/tokens/0x2604fa406be957e542beb89e6754fcde6815e83f.yaml
@@ -8,7 +8,7 @@ description: >-
 links:
 - Bitcointalk: https://bitcointalk.org/index.php?topic=2073668.0
 - Blog: https://medium.com/@playkey
-- CoinMarketCap: playkey
+- CoinMarketCap: https://coinmarketcap.com/currencies/playkey/
 - Email: mailto:support@playkey.net
 - Facebook: https://www.facebook.com/groups/playkeyICO/
 - Github: https://github.com/Playkey/

--- a/tokens/0x27054b13b1b798b345b591a4d22e6562d47ea75a.yaml
+++ b/tokens/0x27054b13b1b798b345b591a4d22e6562d47ea75a.yaml
@@ -6,7 +6,7 @@ description: >-
 links:
 - Bitcointalk: https://bitcointalk.org/index.php?topic=2208855.0
 - Blog: https://medium.com/@airswap
-- CoinMarketCap: airswap
+- CoinMarketCap: https://coinmarketcap.com/currencies/airswap/
 - Email: mailto:team@airswap.io
 - Facebook: https://www.facebook.com/airswapio
 - Github: https://github.com/airswap

--- a/tokens/0x27695e09149adc738a978e9a678f99e4c39e9eb9.yaml
+++ b/tokens/0x27695e09149adc738a978e9a678f99e4c39e9eb9.yaml
@@ -8,7 +8,7 @@ description: >-
 links:
 - Bitcointalk: https://bitcointalk.org/index.php?topic=2046684.0
 - Blog: https://medium.com/@kickico
-- CoinMarketCap: kickico
+- CoinMarketCap: https://coinmarketcap.com/currencies/kickico/
 - Email: mailto:support@kickico.com
 - Facebook: https://www.facebook.com/kickicoplatform/
 - Github: https://github.com/kickico

--- a/tokens/0x27dce1ec4d3f72c3e457cc50354f1f975ddef488.yaml
+++ b/tokens/0x27dce1ec4d3f72c3e457cc50354f1f975ddef488.yaml
@@ -9,7 +9,7 @@ description: >-
 links:
 - Bitcointalk: https://bitcointalk.org/index.php?topic=2078932
 - Blog: https://medium.com/@airfox
-- CoinMarketCap: airtoken
+- CoinMarketCap: https://coinmarketcap.com/currencies/airtoken/
 - Email: mailto:corporate@airfox.io
 - Reddit: https://www.reddit.com/r/AirToken/
 - Slack: https://shielded-mesa-79992.herokuapp.com/

--- a/tokens/0x27f610bf36eca0939093343ac28b1534a721dbb4.yaml
+++ b/tokens/0x27f610bf36eca0939093343ac28b1534a721dbb4.yaml
@@ -5,7 +5,7 @@ description: >-
   Token trading
 links:
 - Blog: https://blog.wandx.co/
-- CoinMarketCap: wandx
+- CoinMarketCap: https://coinmarketcap.com/currencies/wandx/
 - Email: mailto:marketing@wandx.co
 - Facebook: https://www.facebook.com/wandx.co/
 - Github: https://github.com/WandXDapp

--- a/tokens/0x286bda1413a2df81731d4930ce2f862a35a609fe.yaml
+++ b/tokens/0x286bda1413a2df81731d4930ce2f862a35a609fe.yaml
@@ -8,7 +8,7 @@ description: >-
 links:
 - Bitcointalk: https://bitcointalk.org/index.php?topic=2038385.0
 - Blog: https://medium.com/@wabiico
-- CoinMarketCap: wabi
+- CoinMarketCap: https://coinmarketcap.com/currencies/wabi/
 - Email: mailto:support@wacoin.io
 - Facebook: https://www.facebook.com/wabiico/
 - Reddit: https://www.reddit.com/r/WabiToken/

--- a/tokens/0x28c8d01ff633ea9cd8fc6a451d7457889e698de6.yaml
+++ b/tokens/0x28c8d01ff633ea9cd8fc6a451d7457889e698de6.yaml
@@ -5,7 +5,7 @@ description: >-
   Ethereum gold
 links:
 - Bitcointalk: https://bitcointalk.org/index.php?topic=2263898.0
-- CoinMarketCap: ethereum-gold
+- CoinMarketCap: https://coinmarketcap.com/currencies/ethereum-gold/
 - Email: mailto:dev@ethereumgold.info
 - Github: https://gist.github.com/ETGs/b44d58284be31e1a83e1490dce1ea07e
 - Telegram: https://t.me/joinchat/GzPNJhCuW5Lw862j_qJy3g

--- a/tokens/0x29d75277ac7f0335b2165d0895e8725cbf658d73.yaml
+++ b/tokens/0x29d75277ac7f0335b2165d0895e8725cbf658d73.yaml
@@ -8,7 +8,7 @@ description: >-
 links:
 - Bitcointalk: https://bitcointalk.org/index.php?topic=2047543.0
 - Blog: https://medium.com/@bitdice
-- CoinMarketCap: bitdice
+- CoinMarketCap: https://coinmarketcap.com/currencies/bitdice/
 - Email: mailto:contact@bitdice.me
 - Github: https://github.com/bitdice-me/csno
 - Reddit: https://www.reddit.com/r/BitDiceCasino/

--- a/tokens/0x2a05d22db079bc40c2f77a1d1ff703a56e631cc1.yaml
+++ b/tokens/0x2a05d22db079bc40c2f77a1d1ff703a56e631cc1.yaml
@@ -7,7 +7,7 @@ description: >-
 links:
 - Bitcointalk: https://bitcointalk.org/index.php?topic=1946768.0
 - Blog: https://www.bitasean.org/news-updates
-- CoinMarketCap: bitasean
+- CoinMarketCap: https://coinmarketcap.com/currencies/bitasean/
 - Email: mailto:bytecodeteam@gmail.com
 - Facebook: https://www.facebook.com/BitAsean/
 - Twitter: https://twitter.com/BitAseanTeam

--- a/tokens/0x2bdc0d42996017fce214b21607a515da41a9e0c5.yaml
+++ b/tokens/0x2bdc0d42996017fce214b21607a515da41a9e0c5.yaml
@@ -5,7 +5,7 @@ description: >-
   Universal Cryptocurrency based on Ethereum for instant trading of CS:GO, Dota 2 skins, and making bets
   on eSports events.
 links:
-- CoinMarketCap: skincoin
+- CoinMarketCap: https://coinmarketcap.com/currencies/skincoin/
 - Email: mailto:crowdsale@skincoin.org
 - Facebook: https://www.facebook.com/skincoin/
 - Github: https://github.com/Steamtradenet/smart-contract

--- a/tokens/0x2c82c73d5b34aa015989462b2948cd616a37641f.yaml
+++ b/tokens/0x2c82c73d5b34aa015989462b2948cd616a37641f.yaml
@@ -9,7 +9,7 @@ description: >-
 links:
 - Bitcointalk: https://bitcointalk.org/index.php?topic=2169122.0
 - Blog: https://medium.com/teamspectreai
-- CoinMarketCap: spectre-utility
+- CoinMarketCap: https://coinmarketcap.com/currencies/spectre-utility/
 - Email: mailto:team@spectre.ai
 - Facebook: https://www.facebook.com/spectrepage/
 - Github: https://github.com/spectre-ai

--- a/tokens/0x2c974b2d0ba1716e644c1fc59982a89ddd2ff724.yaml
+++ b/tokens/0x2c974b2d0ba1716e644c1fc59982a89ddd2ff724.yaml
@@ -9,7 +9,7 @@ description: >-
 links:
 - Bitcointalk: https://bitcointalk.org/index.php?topic=2029450.0
 - Blog: https://medium.com/viberate-blog
-- CoinMarketCap: viberate
+- CoinMarketCap: https://coinmarketcap.com/currencies/viberate/
 - Email: mailto:ico@viberate.com
 - Facebook: https://www.facebook.com/viberateOFC/
 - Telegram: https://t.me/joinchat/F-zenkQffjbGY7YqqSQl1w

--- a/tokens/0x2daee1aa61d60a252dc80564499a69802853583a.yaml
+++ b/tokens/0x2daee1aa61d60a252dc80564499a69802853583a.yaml
@@ -6,7 +6,7 @@ description: >-
 links:
 - Bitcointalk: https://bitcointalk.org/index.php?topic=2058499
 - Blog: http://authorship.com/category/blog/
-- CoinMarketCap: authorship
+- CoinMarketCap: https://coinmarketcap.com/currencies/authorship/
 - Website: http://authorship.com/
 - Whitepaper: https://view.joomag.com/authorship-white-paper-authorship-white-paper/0120750001501521493?short
 name: Authorship Token

--- a/tokens/0x2e071d2966aa7d8decb1005885ba1977d6038a65.yaml
+++ b/tokens/0x2e071d2966aa7d8decb1005885ba1977d6038a65.yaml
@@ -12,7 +12,7 @@ description: >-
   blockchain.
 links:
 - Blog: https://etheroll.wordpress.com/
-- CoinMarketCap: etheroll
+- CoinMarketCap: https://coinmarketcap.com/currencies/etheroll/
 - Email: mailto:support@etheroll.com
 - Website: http://etheroll.com
 - Website: http://etheroll.com/

--- a/tokens/0x2fa32a39fc1c399e0cc7b2935868f5165de7ce97.yaml
+++ b/tokens/0x2fa32a39fc1c399e0cc7b2935868f5165de7ce97.yaml
@@ -6,7 +6,7 @@ description: >-
 links:
 - Bitcointalk: https://bitcointalk.org/index.php?topic=2127946
 - Blog: https://payfair.io/en/blog
-- CoinMarketCap: payfair
+- CoinMarketCap: https://coinmarketcap.com/currencies/payfair/
 - Email: mailto:support@payfair.io
 - Facebook: https://www.facebook.com/Payfairio/
 - Github: https://github.com/payfairio/

--- a/tokens/0x336f646f87d9f6bc6ed42dd46e8b3fd9dbd15c22.yaml
+++ b/tokens/0x336f646f87d9f6bc6ed42dd46e8b3fd9dbd15c22.yaml
@@ -11,7 +11,7 @@ description: >-
 links:
 - Bitcointalk: https://bitcointalk.org/index.php?topic=2046788.0
 - Blog: https://steemit.com/@crysser
-- CoinMarketCap: crystal-clear
+- CoinMarketCap: https://coinmarketcap.com/currencies/crystal-clear/
 - Email: mailto:ccs@crystal-clear.io
 - Facebook: https://www.facebook.com/CCSer/
 - Github: https://github.com/CrystalClearS

--- a/tokens/0x340d2bde5eb28c1eed91b2f790723e3b160613b7.yaml
+++ b/tokens/0x340d2bde5eb28c1eed91b2f790723e3b160613b7.yaml
@@ -14,7 +14,7 @@ description: >-
   networks.
 links:
 - Blog: https://medium.com/@blockv_io
-- CoinMarketCap: blockv
+- CoinMarketCap: https://coinmarketcap.com/currencies/blockv/
 - Facebook: https://www.facebook.com/blockv.io
 - Github: https://github.com/BLOCKvIO/documentation
 - Reddit: https://www.reddit.com/r/blockv/

--- a/tokens/0x3597bfd533a99c9aa083587b074434e61eb0a258.yaml
+++ b/tokens/0x3597bfd533a99c9aa083587b074434e61eb0a258.yaml
@@ -4,7 +4,7 @@ decimals: 8
 description: >-
   Tokenizing the Mobile Data Industry
 links:
-- CoinMarketCap: dent
+- CoinMarketCap: https://coinmarketcap.com/currencies/dent/
 - Email: mailto:info@dentcoin.com
 - Facebook: https://facebook.com/dentcoin
 - Slack: https://dentcoin.herokuapp.com/

--- a/tokens/0x3833dda0aeb6947b98ce454d89366cba8cc55528.yaml
+++ b/tokens/0x3833dda0aeb6947b98ce454d89366cba8cc55528.yaml
@@ -7,7 +7,7 @@ description: >-
 links:
 - Bitcointalk: https://bitcointalk.org/index.php?topic=2214715.0
 - Blog: https://www.sophiatx.com/blog.html
-- CoinMarketCap: sophiatx
+- CoinMarketCap: https://coinmarketcap.com/currencies/sophiatx/
 - Email: mailto:info@sophiatx.com
 - Facebook: https://www.facebook.com/SophiaTXC/
 - Reddit: https://www.reddit.com/r/SophiaTXproject/

--- a/tokens/0x386467f1f3ddbe832448650418311a479eecfc57.yaml
+++ b/tokens/0x386467f1f3ddbe832448650418311a479eecfc57.yaml
@@ -10,7 +10,7 @@ description: >-
   not only a seat license for the Platform, but are also accepted as a form of payment on TokenVerse for
   our products and services offered on the site.
 links:
-- CoinMarketCap: embers
+- CoinMarketCap: https://coinmarketcap.com/currencies/embers/
 - Email: mailto:info@embermine.com
 - Facebook: https://www.facebook.com/embermine
 - Twitter: https://twitter.com/TheEmbermine

--- a/tokens/0x3adfc4999f77d04c8341bac5f3a76f58dff5b37a.yaml
+++ b/tokens/0x3adfc4999f77d04c8341bac5f3a76f58dff5b37a.yaml
@@ -7,7 +7,7 @@ description: >-
 links:
 - Bitcointalk: https://bitcointalk.org/index.php?topic=2254209
 - Blog: https://medium.com/privatix
-- CoinMarketCap: privatix
+- CoinMarketCap: https://coinmarketcap.com/currencies/privatix/
 - Email: mailto:support@privatix.io
 - Facebook: https://www.facebook.com/Privatix.ltd/
 - Github: https://github.com/Privatix

--- a/tokens/0x3d1ba9be9f66b8ee101911bc36d3fb562eac2244.yaml
+++ b/tokens/0x3d1ba9be9f66b8ee101911bc36d3fb562eac2244.yaml
@@ -5,7 +5,7 @@ description: >-
   The Decentralized &amp; Mobile Cyber Security Token
 links:
 - Bitcointalk: https://bitcointalk.org/index.php?topic=1989333.0
-- CoinMarketCap: rivetz
+- CoinMarketCap: https://coinmarketcap.com/currencies/rivetz/
 - Email: mailto:sales@rivetzintl.com
 - Facebook: https://www.facebook.com/Rivetzcorp/
 - Telegram: https://t.me/rivet_group

--- a/tokens/0x40395044ac3c0c57051906da938b54bd6557f212.yaml
+++ b/tokens/0x40395044ac3c0c57051906da938b54bd6557f212.yaml
@@ -5,7 +5,7 @@ description: >-
   The First Crypto-Centric Mobile Gaming Platform and Store For In-Game Purchases.
 links:
 - Blog: https://mobilego.io/blog/
-- CoinMarketCap: mobilego
+- CoinMarketCap: https://coinmarketcap.com/currencies/mobilego/
 - Facebook: https://www.facebook.com/MobileGo-ICO-1967836613444499/
 - Slack: https://gamecredits.com/slack.html
 - Telegram: https://t.me/mobilego

--- a/tokens/0x4156d3342d5c385a87d264f90653733592000581.yaml
+++ b/tokens/0x4156d3342d5c385a87d264f90653733592000581.yaml
@@ -4,7 +4,7 @@ decimals: 8
 description: >-
   Blockchain-Backed Loans
 links:
-- CoinMarketCap: salt
+- CoinMarketCap: https://coinmarketcap.com/currencies/salt/
 - Email: mailto:support@saltlending.com
 - Facebook: http://facebook.com/SALTLENDING/
 - Telegram: https://t.me/joinchat/BmtZ5kKgf4ekiNLggHRDmQ

--- a/tokens/0x419c4db4b9e25d6db2ad9691ccb832c8d9fda05e.yaml
+++ b/tokens/0x419c4db4b9e25d6db2ad9691ccb832c8d9fda05e.yaml
@@ -5,7 +5,7 @@ description: >-
   Be a part of the most secure, flexible, and business ready blockchain platform, and ecosystem.
 links:
 - Bitcointalk: https://bitcointalk.org/index.php?topic=2096284.0
-- CoinMarketCap: dragonchain
+- CoinMarketCap: https://coinmarketcap.com/currencies/dragonchain/
 - Email: mailto:tokensale@dragonchain.com
 - Github: https://github.com/dragonchain/dragonchain
 - Slack: https://dragonchain.slack.com/

--- a/tokens/0x419d0d8bdd9af5e606ae2232ed285aff190e711b.yaml
+++ b/tokens/0x419d0d8bdd9af5e606ae2232ed285aff190e711b.yaml
@@ -7,7 +7,7 @@ description: >-
   unplayable.
 links:
 - Blog: https://funfair.io/blog/
-- CoinMarketCap: funfair
+- CoinMarketCap: https://coinmarketcap.com/currencies/funfair/
 - Email: mailto:info@funfair.io
 - Facebook: https://www.facebook.com/groups/148397155706069/
 - Reddit: https://www.reddit.com/r/FunfairTech/

--- a/tokens/0x41e5560054824ea6b0732e656e3ad64e20e94e45.yaml
+++ b/tokens/0x41e5560054824ea6b0732e656e3ad64e20e94e45.yaml
@@ -9,7 +9,7 @@ description: >-
   or physical hardware token.
 links:
 - Blog: https://vinnylingham.com/
-- CoinMarketCap: civic
+- CoinMarketCap: https://coinmarketcap.com/currencies/civic/
 - Facebook: https://www.facebook.com/pg/civictechnologiesinc/about/?ref=page_internal
 - Telegram: https://t.me/civicplatform
 - Twitter: https://twitter.com/civickey

--- a/tokens/0x422866a8f0b032c5cf1dfbdef31a20f4509562b0.yaml
+++ b/tokens/0x422866a8f0b032c5cf1dfbdef31a20f4509562b0.yaml
@@ -7,7 +7,7 @@ description: >-
 links:
 - Bitcointalk: https://bitcointalk.org/index.php?topic=1994545.0
 - Blog: https://medium.com/adshares
-- CoinMarketCap: adshares
+- CoinMarketCap: https://coinmarketcap.com/currencies/adshares/
 - Email: mailto:office@adshares.net
 - Facebook: https://facebook.com/adshares/
 - Github: https://github.com/adshares

--- a/tokens/0x42d6622dece394b54999fbd73d108123806f6a18.yaml
+++ b/tokens/0x42d6622dece394b54999fbd73d108123806f6a18.yaml
@@ -5,7 +5,7 @@ description: >-
   Blockchain-based infrastructure for the Adult industry.
 links:
 - Blog: https://medium.com/spankchain
-- CoinMarketCap: spankchain
+- CoinMarketCap: https://coinmarketcap.com/currencies/spankchain/
 - Email: mailto:hello@spankchain.com
 - Github: https://github.com/spankchain
 - Reddit: https://www.reddit.com/r/SpankChain/

--- a/tokens/0x4355fc160f74328f9b383df2ec589bb3dfd82ba0.yaml
+++ b/tokens/0x4355fc160f74328f9b383df2ec589bb3dfd82ba0.yaml
@@ -6,7 +6,7 @@ description: >-
 links:
 - Bitcointalk: https://bitcointalk.org/index.php?topic=2011065
 - Blog: https://opus-foundation.org/index.php/blog/
-- CoinMarketCap: opus
+- CoinMarketCap: https://coinmarketcap.com/currencies/opus/
 - Email: mailto:info@opus-foundation.org
 - Facebook: https://www.facebook.com/Opus-129701967624235/
 - Github: https://github.com/Opus-foundation/

--- a/tokens/0x43ee79e379e7b78d871100ed696e803e7893b644.yaml
+++ b/tokens/0x43ee79e379e7b78d871100ed696e803e7893b644.yaml
@@ -6,7 +6,7 @@ description: >-
   account system (DAS) based on blockchain technology. The system has built-in exclusive token UG Token
   (UGT), which simultaneously has the equity attribute and monetary attribute.
 links:
-- CoinMarketCap: ug-token
+- CoinMarketCap: https://coinmarketcap.com/currencies/ug-token/
 - Website: http://ugchain.org/
 name: UG Token
 notice: >-

--- a/tokens/0x44197a4c44d6a059297caf6be4f7e172bd56caaf.yaml
+++ b/tokens/0x44197a4c44d6a059297caf6be4f7e172bd56caaf.yaml
@@ -8,7 +8,7 @@ description: >-
 links:
 - Bitcointalk: https://bitcointalk.org/index.php?topic=2259761.0
 - Blog: https://medium.com/@officialELTCoin
-- CoinMarketCap: eltcoin
+- CoinMarketCap: https://coinmarketcap.com/currencies/eltcoin/
 - Email: mailto:eltcoin@gmail.com
 - Facebook: https://www.facebook.com/eltcoin.community/
 - Github: https://github.com/ELTCOIN

--- a/tokens/0x4470bb87d77b963a013db939be332f927f2b992e.yaml
+++ b/tokens/0x4470bb87d77b963a013db939be332f927f2b992e.yaml
@@ -11,7 +11,7 @@ description: >-
   We believe we can empower advertisers and publishers with a platform that is secure, transparent and
   beneficial for all the parties involved in the process, consumers included.
 links:
-- CoinMarketCap: adx-net
+- CoinMarketCap: https://coinmarketcap.com/currencies/adx-net/
 - Website: https://www.adex.network/
 name: AdEx
 symbol: ADX

--- a/tokens/0x45e42d659d9f9466cd5df622506033145a9b89bc.yaml
+++ b/tokens/0x45e42d659d9f9466cd5df622506033145a9b89bc.yaml
@@ -8,7 +8,7 @@ description: >-
 
   The Nexium is the Token of Beyond the void. It will be used in our shop to trade items.
 links:
-- CoinMarketCap: nexium
+- CoinMarketCap: https://coinmarketcap.com/currencies/nexium/
 - Website: https://beyond-the-void.net/
 - Website: http://beyond-the-void.net
 name: Nexium

--- a/tokens/0x46492473755e8df960f8034877f61732d718ce96.yaml
+++ b/tokens/0x46492473755e8df960f8034877f61732d718ce96.yaml
@@ -21,7 +21,7 @@ description: >-
 links:
 - Bitcointalk: https://bitcointalk.org/index.php?topic=1759190.0;all
 - Blog: https://backto.earth/blog/
-- CoinMarketCap: starcredits
+- CoinMarketCap: https://coinmarketcap.com/currencies/starcredits/
 - Email: mailto:contact@backto.earth
 - Facebook: https://www.facebook.com/backtoearthproductions/
 - Github: https://github.com/sprux/BackToEarth

--- a/tokens/0x47dd62d4d075dead71d0e00299fc56a2d747bebb.yaml
+++ b/tokens/0x47dd62d4d075dead71d0e00299fc56a2d747bebb.yaml
@@ -10,7 +10,7 @@ description: >-
 links:
 - Bitcointalk: https://bitcointalk.org/index.php?topic=2814625
 - Blog: https://medium.com/@EqualToken
-- CoinMarketCap: https://coinmarketcap.com/currencies/equal
+- CoinMarketCap: https://coinmarketcap.com/currencies/equal/
 - Email: mailto:hello@equaltoken.io
 - Reddit: https://reddit.com/r/EQUAL_Network
 - Telegram: https://t.me/joinchat/GtLjl1JMYiTHzhaQA5CGPw

--- a/tokens/0x48f775efbe4f5ece6e0df2f7b5932df56823b990.yaml
+++ b/tokens/0x48f775efbe4f5ece6e0df2f7b5932df56823b990.yaml
@@ -5,7 +5,7 @@ description: >-
   First Unbiased Review Platform, Built With Blockchain Technology.
 links:
 - Blog: https://medium.com/revain
-- CoinMarketCap: revain
+- CoinMarketCap: https://coinmarketcap.com/currencies/revain/
 - Email: mailto:contact@revain.org
 - Facebook: https://www.facebook.com/revain.org/
 - Github: https://github.com/Revain/Token

--- a/tokens/0x49aec0752e68d0282db544c677f6ba407ba17ed7.yaml
+++ b/tokens/0x49aec0752e68d0282db544c677f6ba407ba17ed7.yaml
@@ -9,7 +9,7 @@ description: >-
   provide intrinsic value to the token and differentiate it from the competition.
 links:
 - Bitcointalk: https://bitcointalk.org/index.php?topic=2065888
-- CoinMarketCap: billionaire-token
+- CoinMarketCap: https://coinmarketcap.com/currencies/billionaire-token/
 - Email: mailto:billionaire@BillionaireToken.com
 - Github: https://github.com/billionairetoken/TokenCore
 - Slack: https://billionairetoken.herokuapp.com/

--- a/tokens/0x4ceda7906a5ed2179785cd3a40a69ee8bc99c466.yaml
+++ b/tokens/0x4ceda7906a5ed2179785cd3a40a69ee8bc99c466.yaml
@@ -7,7 +7,7 @@ description: >-
 links:
 - Bitcointalk: https://bitcointalk.org/index.php?topic=2215642.0
 - Blog: https://blog.aion.network/
-- CoinMarketCap: aion
+- CoinMarketCap: https://coinmarketcap.com/currencies/aion/
 - Email: mailto:hello@aion.network
 - Facebook: https://www.facebook.com/AionBlockchain
 - Github: https://github.com/gonuco/aion.erc.contract

--- a/tokens/0x4dc3643dbc642b72c158e7f3d2ff232df61cb6ce.yaml
+++ b/tokens/0x4dc3643dbc642b72c158e7f3d2ff232df61cb6ce.yaml
@@ -7,7 +7,7 @@ description: >-
 links:
 - Bitcointalk: https://bitcointalk.org/index.php?topic=2034826.0
 - Blog: https://blog.ambrosus.com/
-- CoinMarketCap: amber
+- CoinMarketCap: https://coinmarketcap.com/currencies/amber/
 - Email: mailto:info@ambrosus.com
 - Facebook: https://www.facebook.com/ambrosusAMB
 - Github: https://github.com/ambrosus

--- a/tokens/0x4df812f6064def1e5e029f1ca858777cc98d2d81.yaml
+++ b/tokens/0x4df812f6064def1e5e029f1ca858777cc98d2d81.yaml
@@ -8,7 +8,7 @@ description: >-
   value. The CommonWealth is maintained by Auresco Institute physically and Ethereum network digitally.
 links:
 - Bitcointalk: https://www.bitcointalk.org/index.php?topic=1546279.0
-- CoinMarketCap: xaurum
+- CoinMarketCap: https://coinmarketcap.com/currencies/xaurum/
 - Facebook: https://www.facebook.com/xaurumofficial/
 - Github: https://github.com/XaurumTeam/XaurumOnEthereum
 - Twitter: https://www.twitter.com/urumproject

--- a/tokens/0x4e0603e2a27a30480e5e3a4fe548e29ef12f64be.yaml
+++ b/tokens/0x4e0603e2a27a30480e5e3a4fe548e29ef12f64be.yaml
@@ -6,7 +6,7 @@ description: >-
   the cryptocurrency spam solution BitBounce. Credos create a market for email that allows users to charge
   to recieve emails from unknown senders.
 links:
-- CoinMarketCap: credo
+- CoinMarketCap: https://coinmarketcap.com/currencies/credo/
 - Email: mailto:info@team.bitbounce.io
 - Facebook: https://www.facebook.com/groups/231924857297898/
 - Slack: https://join.slack.com/t/credoowners/shared_invite/MjE4MjkzNzgyNTEzLTE1MDExOTc3MTYtZmUwYWVjYWUzNA

--- a/tokens/0x50ee674689d75c0f88e8f83cfe8c4b69e8fd590d.yaml
+++ b/tokens/0x50ee674689d75c0f88e8f83cfe8c4b69e8fd590d.yaml
@@ -8,7 +8,7 @@ description: >-
   way to better travel experiences, discovering new destinations, meeting new people.
 links:
 - Bitcointalk: https://bitcointalk.org/index.php?topic=2147509
-- CoinMarketCap: emphy
+- CoinMarketCap: https://coinmarketcap.com/currencies/emphy/
 - Email: mailto:info@emphy.io
 - Facebook: https://www.facebook.com/emphy.io
 - Slack: https://emphyofficial.slack.com/

--- a/tokens/0x5121e348e897daef1eef23959ab290e5557cf274.yaml
+++ b/tokens/0x5121e348e897daef1eef23959ab290e5557cf274.yaml
@@ -16,7 +16,7 @@ description: >-
   2018, with supporting functions for the market such as pricing Bitcoin and trading supports.
 links:
 - Bitcointalk: https://bitcointalk.org/index.php?topic=2307231
-- CoinMarketCap: poly-ai
+- CoinMarketCap: https://coinmarketcap.com/currencies/poly-ai/
 - Email: mailto:support@polynetwork.org
 - Facebook: https://www.facebook.com/networkpoly/
 - Reddit: https://www.reddit.com/r/Bitcoin/comments/788fr5/poly_ai_artificial_intelligence_base_on/?st=j9qqf1n6&sh=18310914

--- a/tokens/0x514910771af9ca656af840dff83e8264ecf986ca.yaml
+++ b/tokens/0x514910771af9ca656af840dff83e8264ecf986ca.yaml
@@ -7,7 +7,7 @@ description: >-
   who has a data feed, useful off-chain service such as local payments, or any other API, can now provide
   them directly to smart contracts in exchange for LINK tokens.
 links:
-- CoinMarketCap: chainlink
+- CoinMarketCap: https://coinmarketcap.com/currencies/chainlink/
 - Email: mailto:chainlink@smartcontract.com
 - Twitter: https://twitter.com/smart_contract
 - Website: https://link.smartcontract.com/

--- a/tokens/0x519475b31653e46d20cd09f9fdcf3b12bdacb4f5.yaml
+++ b/tokens/0x519475b31653e46d20cd09f9fdcf3b12bdacb4f5.yaml
@@ -7,7 +7,7 @@ description: >-
 links:
 - Bitcointalk: https://bitcointalk.org/index.php?topic=2353646.0
 - Blog: https://medium.com/@Viuly
-- CoinMarketCap: viuly
+- CoinMarketCap: https://coinmarketcap.com/currencies/viuly/
 - Email: mailto:support@viuly.com
 - Facebook: https://www.facebook.com/viuly/
 - Github: https://github.com/viuly

--- a/tokens/0x51db5ad35c671a87207d88fc11d593ac0c8415bd.yaml
+++ b/tokens/0x51db5ad35c671a87207d88fc11d593ac0c8415bd.yaml
@@ -9,7 +9,7 @@ description: >-
 links:
 - Bitcointalk: https://bitcointalk.org/index.php?topic=2027555.0
 - Blog: https://medium.com/moeda
-- CoinMarketCap: moeda-loyalty-points
+- CoinMarketCap: https://coinmarketcap.com/currencies/moeda-loyalty-points/
 - Email: mailto:contact@moeda.in
 - Facebook: https://www.facebook.com/moedabanking
 - Github: https://github.com/moedabank

--- a/tokens/0x51ee82641ac238bde34b9859f98f5f311d6e4954.yaml
+++ b/tokens/0x51ee82641ac238bde34b9859f98f5f311d6e4954.yaml
@@ -5,7 +5,7 @@ description: >-
   Decentralized quantitative assets trading
 links:
 - Bitcointalk: https://bitcointalk.org/index.php?topic=2198858.0
-- CoinMarketCap: iquant
+- CoinMarketCap: https://coinmarketcap.com/currencies/iquant/
 - Email: mailto:iqt@5iquant.com
 - Reddit: https://www.reddit.com/user/IQTChain
 - Slack: https://iqt-group.slack.com/

--- a/tokens/0x539efe69bcdd21a83efd9122571a64cc25e0282b.yaml
+++ b/tokens/0x539efe69bcdd21a83efd9122571a64cc25e0282b.yaml
@@ -6,7 +6,7 @@ description: >-
   without sacrificing your security.
 links:
 - Bitcointalk: https://bitcointalk.org/index.php?topic=2279214.0
-- CoinMarketCap: ethereum-blue
+- CoinMarketCap: https://coinmarketcap.com/currencies/ethereum-blue/
 - Email: mailto:team@etherblue.org
 - Github: https://github.com/ethblue
 - Telegram: https://t.me/joinchat/HBDo00IO49STMJuIwJi08g

--- a/tokens/0x554c20b7c486beee439277b4540a434566dc4c02.yaml
+++ b/tokens/0x554c20b7c486beee439277b4540a434566dc4c02.yaml
@@ -9,7 +9,7 @@ description: >-
 links:
 - Bitcointalk: https://bitcointalk.org/index.php?topic=2187641.0
 - Blog: https://medium.com/horizonstate
-- CoinMarketCap: decision-token
+- CoinMarketCap: https://coinmarketcap.com/currencies/decision-token/
 - Email: mailto:inbox@horizonstate.com
 - Facebook: https://www.facebook.com/HorizonState/
 - Github: https://github.com/HorizonState/token-sale

--- a/tokens/0x5554e04e76533e1d14c52f05beef6c9d329e1e30.yaml
+++ b/tokens/0x5554e04e76533e1d14c52f05beef6c9d329e1e30.yaml
@@ -14,7 +14,7 @@ description: >-
   platforms.
 links:
 - Bitcointalk: https://bitcointalk.org/index.php?topic=2138049.0
-- CoinMarketCap: autonio
+- CoinMarketCap: https://coinmarketcap.com/currencies/autonio/
 - Email: mailto:contact@auton.io
 - Telegram: https://t.me/Autonio
 - Website: https://auton.io/

--- a/tokens/0x55648de19836338549130b1af587f16bea46f66b.yaml
+++ b/tokens/0x55648de19836338549130b1af587f16bea46f66b.yaml
@@ -6,7 +6,7 @@ description: >-
 links:
 - Bitcointalk: https://bitcointalk.org/index.php?topic=2079885
 - Blog: https://medium.com/publicaio
-- CoinMarketCap: publica
+- CoinMarketCap: https://coinmarketcap.com/currencies/publica/
 - Email: mailto:info@publica.io
 - Facebook: https://www.facebook.com/OfficialPublica/
 - Github: https://github.com/PublicaIO

--- a/tokens/0x56ba2ee7890461f463f7be02aac3099f6d5811a8.yaml
+++ b/tokens/0x56ba2ee7890461f463f7be02aac3099f6d5811a8.yaml
@@ -6,7 +6,7 @@ description: >-
   a few clicks. No programming required.
 links:
 - Blog: https://medium.com/@blockcat
-- CoinMarketCap: blockcat
+- CoinMarketCap: https://coinmarketcap.com/currencies/blockcat/
 - Email: mailto:team@blockcat.io
 - Slack: https://slack.blockcat.io/
 - Twitter: https://twitter.com/blockcatio

--- a/tokens/0x595832f8fc6bf59c85c527fec3740a1b7a361269.yaml
+++ b/tokens/0x595832f8fc6bf59c85c527fec3740a1b7a361269.yaml
@@ -7,7 +7,7 @@ description: >-
 links:
 - Bitcointalk: https://bitcointalk.org/index.php?topic=2003922.0
 - Blog: https://medium.com/power-ledger
-- CoinMarketCap: power-ledger
+- CoinMarketCap: https://coinmarketcap.com/currencies/power-ledger/
 - Email: mailto:support@powerledger.io
 - Facebook: https://www.facebook.com/powerledger
 - Reddit: https://www.reddit.com/r/icocrypto/comments/6mr791/power_ledger_token_sale_powr/

--- a/tokens/0x5B0751713b2527d7f002c0c4e2a37e1219610A6B.yaml
+++ b/tokens/0x5B0751713b2527d7f002c0c4e2a37e1219610A6B.yaml
@@ -14,7 +14,7 @@ description: >-
 links:
 - Bitcointalk: https://bitcointalk.org/index.php?topic=2573978.0
 - Blog: https://medium.com/@ethorse
-- CoinMarketCap: ethorse
+- CoinMarketCap: https://coinmarketcap.com/currencies/ethorse/
 - Email: mailto:support@ethorse.com
 - Github: https://github.com/ethorse
 - Reddit: https://www.reddit.com/r/Ethorse/

--- a/tokens/0x5a84969bb663fb64f6d015dcf9f622aedc796750.yaml
+++ b/tokens/0x5a84969bb663fb64f6d015dcf9f622aedc796750.yaml
@@ -4,7 +4,7 @@ decimals: 18
 description: >-
   We are, without a doubt, the fastest growing blockchain game in the world already.
 links:
-- CoinMarketCap: idice
+- CoinMarketCap: https://coinmarketcap.com/currencies/idice/
 - Email: mailto:idice@protonmail.com
 - Telegram: https://t.me/idicegroup
 - Website: https://idice.io/

--- a/tokens/0x5af2be193a6abca9c8817001f45744777db30756.yaml
+++ b/tokens/0x5af2be193a6abca9c8817001f45744777db30756.yaml
@@ -6,7 +6,7 @@ description: >-
   adoption of blockchain technology and democratizing ownership of cryptocurrencies.
 links:
 - Blog: https://www.ethos.io/blog/
-- CoinMarketCap: ethos
+- CoinMarketCap: https://coinmarketcap.com/currencies/ethos/
 - Email: mailto:press@ethos.io
 - Reddit: https://www.reddit.com/r/ethos_io/
 - Telegram: https://t.me/ethos_io

--- a/tokens/0x5c543e7ae0a1104f78406c340e9c64fd9fce5170.yaml
+++ b/tokens/0x5c543e7ae0a1104f78406c340e9c64fd9fce5170.yaml
@@ -9,7 +9,7 @@ description: >-
   Earn ETH from successful Game Projects.
 links:
 - Bitcointalk: https://bitcointalk.org/index.php?topic=1691524.new#new
-- CoinMarketCap: vslice
+- CoinMarketCap: https://coinmarketcap.com/currencies/vslice/
 - Email: mailto:info@vslice.io
 - Slack: https://vdice-slack-invite-page.stamplayapp.com/
 - Telegram: https://telegram.me/joinchat/EHTlBwbUO0xGJlKuSncFyw

--- a/tokens/0x5c6183d10a00cd747a6dbb5f658ad514383e9419.yaml
+++ b/tokens/0x5c6183d10a00cd747a6dbb5f658ad514383e9419.yaml
@@ -7,7 +7,7 @@ description: >-
   individuals and communities worldwide!
 links:
 - Blog: https://medium.com/@bobnexxus
-- CoinMarketCap: nexxus
+- CoinMarketCap: https://coinmarketcap.com/currencies/nexxus/
 - Email: mailto:bob@NexxusPartners.com
 - Github: https://github.com/NexxusUniversity/nexxuscoin
 - Reddit: https://www.reddit.com/r/NexxusRewards/

--- a/tokens/0x5ca9a71b1d01849c0a95490cc00559717fcf0d1d.yaml
+++ b/tokens/0x5ca9a71b1d01849c0a95490cc00559717fcf0d1d.yaml
@@ -6,7 +6,7 @@ description: >-
   governance and global scalability.
 links:
 - Blog: https://blog.aeternity.com/
-- CoinMarketCap: aeternity
+- CoinMarketCap: https://coinmarketcap.com/currencies/aeternity/
 - Email: mailto:info@aeternity.com
 - Facebook: https://www.facebook.com/aeternityproject/
 - Github: https://github.com/aeternity

--- a/tokens/0x5d51fcced3114a8bb5e90cdd0f9d682bcbcc5393.yaml
+++ b/tokens/0x5d51fcced3114a8bb5e90cdd0f9d682bcbcc5393.yaml
@@ -7,7 +7,7 @@ description: >-
   clients.
 links:
 - Bitcointalk: https://bitcointalk.org/index.php?topic=2149935
-- CoinMarketCap: b2bx
+- CoinMarketCap: https://coinmarketcap.com/currencies/b2bx/
 - Email: mailto:ok@b2broker.net
 - Facebook: https://www.facebook.com/B2BX-ICO-693091567555607
 - Telegram: https://t.me/B2BX_ICO_eng

--- a/tokens/0x5d65d971895edc438f465c17db6992698a52318d.yaml
+++ b/tokens/0x5d65d971895edc438f465c17db6992698a52318d.yaml
@@ -6,7 +6,7 @@ description: >-
   open source public chain.
 links:
 - Blog: https://medium.com/@nebulasio
-- CoinMarketCap: nebulas-token
+- CoinMarketCap: https://coinmarketcap.com/currencies/nebulas-token/
 - Email: mailto:contact@nebulas.io
 - Slack: https://nebulasio.slack.com/
 - Twitter: https://twitter.com/nebulasio

--- a/tokens/0x5e3346444010135322268a4630d2ed5f8d09446c.yaml
+++ b/tokens/0x5e3346444010135322268a4630d2ed5f8d09446c.yaml
@@ -6,7 +6,7 @@ description: >-
   Property Globally, Collect Money And Manage Bookings Without Paying Any Commissions To Middlemen.
 links:
 - Blog: https://medium.com/@LockChainCo
-- CoinMarketCap: lockchain
+- CoinMarketCap: https://coinmarketcap.com/currencies/lockchain/
 - Email: mailto:team@lockchain.co
 - Facebook: https://www.facebook.com/LockChainLOK/
 - Github: https://github.com/LockChainLtd/Smart-Contract

--- a/tokens/0x607f4c5bb672230e8672085532f7e901544a7375.yaml
+++ b/tokens/0x607f4c5bb672230e8672085532f7e901544a7375.yaml
@@ -9,7 +9,7 @@ description: >-
 links:
 - Bitcointalk: https://bitcointalk.org/index.php?topic=1746241.0
 - Blog: https://medium.com/iex-ec
-- CoinMarketCap: rlc
+- CoinMarketCap: https://coinmarketcap.com/currencies/rlc/
 - Email: mailto:contact@iex.ec
 - Facebook: https://www.facebook.com/iexecteam/
 - Github: https://github.com/iExecBlockchainComputing

--- a/tokens/0x621d78f2ef2fd937bfca696cabaf9a779f59b3ed.yaml
+++ b/tokens/0x621d78f2ef2fd937bfca696cabaf9a779f59b3ed.yaml
@@ -5,7 +5,7 @@ description: >-
   DEMOCRATIZING VENTURE CAPITALISM
 links:
 - Bitcointalk: https://bitcointalk.org/index.php?topic=1928628
-- CoinMarketCap: dcorp
+- CoinMarketCap: https://coinmarketcap.com/currencies/dcorp/
 - Email: mailto:info@dcorp.it
 - Facebook: https://www.facebook.com/DecentralizedCorporation
 - Github: https://github.com/frankbonnet/DCORP

--- a/tokens/0x6531f133e6deebe7f2dce5a0441aa7ef330b4e53.yaml
+++ b/tokens/0x6531f133e6deebe7f2dce5a0441aa7ef330b4e53.yaml
@@ -8,7 +8,7 @@ description: >-
 links:
 - Bitcointalk: https://www.reddit.com/r/ChronoBank/
 - Blog: https://blog.chronobank.io/
-- CoinMarketCap: chronobank
+- CoinMarketCap: https://coinmarketcap.com/currencies/chronobank/
 - Email: mailto:info@chronobank.io
 - Facebook: https://www.facebook.com/ChronoBank.io
 - Github: https://github.com/ChronoBank

--- a/tokens/0x662abcad0b7f345ab7ffb1b1fbb9df7894f18e66.yaml
+++ b/tokens/0x662abcad0b7f345ab7ffb1b1fbb9df7894f18e66.yaml
@@ -9,7 +9,7 @@ description: >-
 links:
 - Bitcointalk: https://bitcointalk.org/index.php?topic=2113124
 - Blog: https://medium.com/cartaxi
-- CoinMarketCap: cartaxi-token
+- CoinMarketCap: https://coinmarketcap.com/currencies/cartaxi-token/
 - Email: mailto:info@cartaxi.io
 - Facebook: https://www.facebook.com/cartaxi.io/
 - Github: https://github.com/CarTaxiico

--- a/tokens/0x667088b212ce3d06a1b553a7221e1fd19000d9af.yaml
+++ b/tokens/0x667088b212ce3d06a1b553a7221e1fd19000d9af.yaml
@@ -8,7 +8,7 @@ description: >-
 links:
 - Bitcointalk: https://bitcointalk.org/index.php?topic=1477055.0
 - Blog: https://blog.wings.ai/
-- CoinMarketCap: wings
+- CoinMarketCap: https://coinmarketcap.com/currencies/wings/
 - Email: mailto:domi@wings.ai
 - Facebook: https://www.facebook.com/WingsDAO/
 - Reddit: https://reddit.com/r/WingsDAO/

--- a/tokens/0x671abbe5ce652491985342e85428eb1b07bc6c64.yaml
+++ b/tokens/0x671abbe5ce652491985342e85428eb1b07bc6c64.yaml
@@ -5,7 +5,7 @@ description: >-
   The aim of the Quantum project is to bring institutional grade liquidity to cryptocurrency and digital
   asset markets.
 links:
-- CoinMarketCap: quantum
+- CoinMarketCap: https://coinmarketcap.com/currencies/quantum/
 - Email: mailto:support@quantumproject.org
 - Facebook: https://www.facebook.com/QAUProject/
 - Twitter: https://twitter.com/QAUProject

--- a/tokens/0x672a1ad4f667fb18a333af13667aa0af1f5b5bdd.yaml
+++ b/tokens/0x672a1ad4f667fb18a333af13667aa0af1f5b5bdd.yaml
@@ -6,7 +6,7 @@ description: >-
 links:
 - Bitcointalk: https://bitcointalk.org/index.php?topic=2374729.0
 - Blog: https://medium.com/@verify.as
-- CoinMarketCap: verify
+- CoinMarketCap: https://coinmarketcap.com/currencies/verify/
 - Email: mailto:team@verify.as
 - Facebook: https://www.facebook.com/verifyas
 - Github: https://github.com/verifyas/

--- a/tokens/0x6733d909e10ddedb8d6181b213de32a30ceac7ed.yaml
+++ b/tokens/0x6733d909e10ddedb8d6181b213de32a30ceac7ed.yaml
@@ -8,7 +8,7 @@ description: >-
   BitSerial has a clearly transparent development roadmap. All BitSerial wallet versions will be fully
   up to date where customers can secure on wallets or trade seamlessly on the world exchange.
 links:
-- CoinMarketCap: bitserial
+- CoinMarketCap: https://coinmarketcap.com/currencies/bitserial/
 - Email: mailto:support@bitserial.io
 - Github: https://github.com/bitserialio
 - Telegram: https://t.me/BitSerialNews

--- a/tokens/0x679badc551626e01b23ceecefbc9b877ea18fc46.yaml
+++ b/tokens/0x679badc551626e01b23ceecefbc9b877ea18fc46.yaml
@@ -8,7 +8,7 @@ description: >-
   due to variation of cryptocurrency rate.
 links:
 - Bitcointalk: https://bitcointalk.org/index.php?topic=2100088
-- CoinMarketCap: ccore
+- CoinMarketCap: https://coinmarketcap.com/currencies/ccore/
 - Email: mailto:info@ccore.io
 - Facebook: https://www.facebook.com/ccore.io
 - Telegram: https://t.me/ccore_io

--- a/tokens/0x6810e776880c02933d47db1b9fc05908e5386b96.yaml
+++ b/tokens/0x6810e776880c02933d47db1b9fc05908e5386b96.yaml
@@ -6,7 +6,7 @@ description: >-
   prediction market.
 links:
 - Blog: https://medium.com/gnosis-pm
-- CoinMarketCap: gnosis-gno
+- CoinMarketCap: https://coinmarketcap.com/currencies/gnosis-gno/
 - Facebook: https://www.facebook.com/Gnosis.pm/
 - Reddit: https://www.reddit.com/r/gnosisPM/
 - Slack: https://slack.gnosis.pm/

--- a/tokens/0x687174f8c49ceb7729d925c3a961507ea4ac7b28.yaml
+++ b/tokens/0x687174f8c49ceb7729d925c3a961507ea4ac7b28.yaml
@@ -9,7 +9,7 @@ description: >-
 links:
 - Bitcointalk: https://bitcointalk.org/index.php?topic=2197889.0
 - Blog: https://medium.com/@gatcoin
-- CoinMarketCap: https://coinmarketcap.com/currencies/gatcoin
+- CoinMarketCap: https://coinmarketcap.com/currencies/gatcoin/
 - Email: mailto:simon@gatcoin.io
 - Facebook: https://www.facebook.com/gatcoinofficial
 - Github: https://github.com/gatcoin

--- a/tokens/0x68aa3f232da9bdc2343465545794ef3eea5209bd.yaml
+++ b/tokens/0x68aa3f232da9bdc2343465545794ef3eea5209bd.yaml
@@ -4,7 +4,7 @@ decimals: 18
 description: >-
   A state-of-the-art digital asset exchange, EU token marketplace and wallet with powerful security features
 links:
-- CoinMarketCap: mothership
+- CoinMarketCap: https://coinmarketcap.com/currencies/mothership/
 - Email: mailto:hello@mothership.cx
 - Slack: http://slack.mothership.cx/
 - Telegram: https://t.me/mothershipcx

--- a/tokens/0x6aac8cb9861e42bf8259f5abdc6ae3ae89909e11.yaml
+++ b/tokens/0x6aac8cb9861e42bf8259f5abdc6ae3ae89909e11.yaml
@@ -6,7 +6,7 @@ description: >-
   Making bitcoin art by trading colors.
 links:
 - Bitcointalk: https://bitcointalk.org/index.php?topic=2294915
-- CoinMarketCap: bitcoin-red
+- CoinMarketCap: https://coinmarketcap.com/currencies/bitcoin-red/
 - Email: mailto:contact@bitcoinred.io
 - Facebook: https://www.facebook.com/BitcoinRed1/
 - Telegram: https://t.me/BitcoinRedToken

--- a/tokens/0x6f6deb5db0c4994a8283a01d6cfeeb27fc3bbe9c.yaml
+++ b/tokens/0x6f6deb5db0c4994a8283a01d6cfeeb27fc3bbe9c.yaml
@@ -8,7 +8,7 @@ description: >-
 links:
 - Bitcointalk: https://bitcointalk.org/index.php?topic=2175951.0
 - Blog: https://medium.com/@SmartBillions
-- CoinMarketCap: smartbillions
+- CoinMarketCap: https://coinmarketcap.com/currencies/smartbillions/
 - Email: mailto:admin@smartbillions.com
 - Facebook: https://www.facebook.com/smartbns/
 - Github: https://github.com/SmartBillions/SmartBillions/

--- a/tokens/0x6fff3806bbac52a20e0d79bc538d527f6a22c96b.yaml
+++ b/tokens/0x6fff3806bbac52a20e0d79bc538d527f6a22c96b.yaml
@@ -7,7 +7,7 @@ description: >-
 links:
 - Bitcointalk: https://bitcointalk.org/index.php?topic=2112604.0
 - Blog: https://commodityadnetwork.com/blog/
-- CoinMarketCap: commodity-ad-network
+- CoinMarketCap: https://coinmarketcap.com/currencies/commodity-ad-network/
 - Email: mailto:support@commodityadnetwork.com
 - Facebook: https://www.facebook.com/commodityadnet/
 - Github: https://github.com/commodityadnetwork

--- a/tokens/0x701c244b988a513c945973defa05de933b23fe1d.yaml
+++ b/tokens/0x701c244b988a513c945973defa05de933b23fe1d.yaml
@@ -8,7 +8,7 @@ description: >-
 links:
 - Bitcointalk: https://bitcointalk.org/index.php?topic=1943946
 - Blog: https://medium.com/@OAX_Foundation
-- CoinMarketCap: oax
+- CoinMarketCap: https://coinmarketcap.com/currencies/oax/
 - Github: https://github.com/openanx
 - Reddit: https://www.reddit.com/r/OpenANX/
 - Telegram: https://t.me/openanxteam

--- a/tokens/0x705ee96c1c160842c92c1aecfcffccc9c412e3d9.yaml
+++ b/tokens/0x705ee96c1c160842c92c1aecfcffccc9c412e3d9.yaml
@@ -4,7 +4,7 @@ decimals: 18
 description: >-
   ClearPoll is a social public opinion poll network using blockchain to secure votes and poll results.
 links:
-- CoinMarketCap: clearpoll
+- CoinMarketCap: https://coinmarketcap.com/currencies/clearpoll/
 - Email: mailto:info@clearpoll.io
 - Facebook: https://www.facebook.com/groups/306720296476208/
 - Reddit: https://www.reddit.com/r/clearpoll/

--- a/tokens/0x70a72833d6bf7f508c8224ce59ea1ef3d0ea3a38.yaml
+++ b/tokens/0x70a72833d6bf7f508c8224ce59ea1ef3d0ea3a38.yaml
@@ -7,7 +7,7 @@ description: >-
 links:
 - Bitcointalk: https://bitcointalk.org/index.php?topic=2078433.0
 - Blog: https://medium.com/@UTRUST
-- CoinMarketCap: utrust
+- CoinMarketCap: https://coinmarketcap.com/currencies/utrust/
 - Email: mailto:contact@utrust.io
 - Facebook: https://www.facebook.com/utrust.io/
 - Telegram: https://t.me/utrustofficial

--- a/tokens/0x72adadb447784dd7ab1f472467750fc485e4cb2d.yaml
+++ b/tokens/0x72adadb447784dd7ab1f472467750fc485e4cb2d.yaml
@@ -6,7 +6,7 @@ description: >-
 links:
 - Bitcointalk: https://bitcointalk.org/index.php?topic=2097832
 - Blog: https://worldcore.eu/blog
-- CoinMarketCap: worldcore
+- CoinMarketCap: https://coinmarketcap.com/currencies/worldcore/
 - Email: mailto:ico@worldcore.com
 - Facebook: https://www.facebook.com/worldcoresocial
 - Slack: https://worldcore.slack.com/

--- a/tokens/0x744d70fdbe2ba4cf95131626614a1763df805b9e.yaml
+++ b/tokens/0x744d70fdbe2ba4cf95131626614a1763df805b9e.yaml
@@ -5,7 +5,7 @@ description: >-
   Status is an open source messaging platform and mobile browser to interact with decentralized applications
   that run on the Ethereum Network.
 links:
-- CoinMarketCap: status
+- CoinMarketCap: https://coinmarketcap.com/currencies/status/
 - Facebook: https://www.facebook.com/ethstatus
 - Github: https://github.com/status-im
 - Reddit: https://www.reddit.com/r/statusim/

--- a/tokens/0x74ceda77281b339142a36817fa5f9e29412bab85.yaml
+++ b/tokens/0x74ceda77281b339142a36817fa5f9e29412bab85.yaml
@@ -10,7 +10,7 @@ description: >-
 links:
 - Bitcointalk: https://bitcointalk.org/index.php?topic=2176329.0
 - Blog: https://blog.eroscoin.org/
-- CoinMarketCap: eroscoin
+- CoinMarketCap: https://coinmarketcap.com/currencies/eroscoin/
 - Email: mailto:support@eroscoin.org
 - Facebook: https://www.facebook.com/eroscoin/
 - Github: https://github.com/eroscoin

--- a/tokens/0x7654915a1b82d6d2d0afc37c52af556ea8983c7e.yaml
+++ b/tokens/0x7654915a1b82d6d2d0afc37c52af556ea8983c7e.yaml
@@ -6,7 +6,7 @@ description: >-
 links:
 - Bitcointalk: https://bitcointalk.org/index.php?topic=1989821.0
 - Blog: https://medium.com/@investFeed
-- CoinMarketCap: investfeed
+- CoinMarketCap: https://coinmarketcap.com/currencies/investfeed/
 - Email: mailto:support@investfeed.com
 - Facebook: http://www.facebook.com/investfeed
 - Github: https://github.com/investfeed-corp/feed-token-sale

--- a/tokens/0x78b7fada55a64dd895d8c8c35779dd8b67fa8a05.yaml
+++ b/tokens/0x78b7fada55a64dd895d8c8c35779dd8b67fa8a05.yaml
@@ -6,7 +6,7 @@ description: >-
 links:
 - Bitcointalk: https://bitcointalk.org/index.php?topic=2053239
 - Blog: https://medium.com/@atlantio
-- CoinMarketCap: atlant
+- CoinMarketCap: https://coinmarketcap.com/currencies/atlant/
 - Email: mailto:contact@atlant.io
 - Facebook: https://www.facebook.com/atlantplatform/
 - Github: https://github.com/AtlantPlatform

--- a/tokens/0x7a41e0517a5eca4fdbc7fbeba4d4c47b9ff6dc63.yaml
+++ b/tokens/0x7a41e0517a5eca4fdbc7fbeba4d4c47b9ff6dc63.yaml
@@ -4,7 +4,7 @@ decimals: 18
 description: >-
   Blockchain AI insurance solution
 links:
-- CoinMarketCap: zeusshield
+- CoinMarketCap: https://coinmarketcap.com/currencies/zeusshield/
 - Email: mailto:info@zsc.io
 - Facebook: https://www.facebook.com/shield.zeus
 - Twitter: https://twitter.com/zeusshield

--- a/tokens/0x7b22938ca841aa392c93dbb7f4c42178e3d65e88.yaml
+++ b/tokens/0x7b22938ca841aa392c93dbb7f4c42178e3d65e88.yaml
@@ -6,7 +6,7 @@ description: >-
   to gain exposure to ICOs and undervalued altcoins.
 links:
 - Blog: https://medium.com/astronaut-capital
-- CoinMarketCap: astro
+- CoinMarketCap: https://coinmarketcap.com/currencies/astro/
 - Email: mailto:admin@astronaut.capital
 - Reddit: https://www.reddit.com/r/astronautcapital/
 - Telegram: https://t.me/astroico

--- a/tokens/0x7c5a0ce9267ed19b22f8cae653f198e3e8daf098.yaml
+++ b/tokens/0x7c5a0ce9267ed19b22f8cae653f198e3e8daf098.yaml
@@ -16,7 +16,7 @@ description: >-
   connects the SAN token value directly to the value of datafeeds and information Santiment produces.
 links:
 - Blog: https://medium.com/santiment
-- CoinMarketCap: santiment
+- CoinMarketCap: https://coinmarketcap.com/currencies/santiment/
 - Github: https://github.com/santiment
 - Slack: https://santiment-slack.herokuapp.com/
 - Twitter: https://twitter.com/santimentfeed

--- a/tokens/0x7d4b8cce0591c9044a22ee543533b72e976e36c3.yaml
+++ b/tokens/0x7d4b8cce0591c9044a22ee543533b72e976e36c3.yaml
@@ -6,7 +6,7 @@ description: >-
 links:
 - Bitcointalk: https://bitcointalk.org/index.php?topic=2087937.0
 - Blog: https://medium.com/@changebank
-- CoinMarketCap: change
+- CoinMarketCap: https://coinmarketcap.com/currencies/change/
 - Facebook: https://www.facebook.com/changefinance/
 - Slack: https://coinchange.slack.com/
 - Telegram: https://t.me/joinchat/GWX8HkLwpOoocINbLXfRtg

--- a/tokens/0x80fb784b7ed66730e8b1dbd9820afd29931aab03.yaml
+++ b/tokens/0x80fb784b7ed66730e8b1dbd9820afd29931aab03.yaml
@@ -6,7 +6,7 @@ description: >-
 links:
 - Bitcointalk: https://bitcointalk.org/index.php?topic=2090735.0
 - Blog: https://medium.com/@ethlend1
-- CoinMarketCap: ethlend
+- CoinMarketCap: https://coinmarketcap.com/currencies/ethlend/
 - Email: mailto:hi@ethlend.io
 - Facebook: https://www.facebook.com/ETHLend/
 - Github: https://github.com/ETHLend

--- a/tokens/0x814964b1bceaf24e26296d031eadf134a2ca4105.yaml
+++ b/tokens/0x814964b1bceaf24e26296d031eadf134a2ca4105.yaml
@@ -5,7 +5,7 @@ description: >-
   Newbium (NEWB) is the official cryptocurrrency of the Newbium crypto market information and news platform.
 links:
 - Bitcointalk: https://bitcointalk.org/index.php?topic=1418497.0
-- CoinMarketCap: newbium
+- CoinMarketCap: https://coinmarketcap.com/currencies/newbium/
 - Facebook: https://www.facebook.com/Newbium-602104359952009
 - Twitter: https://twitter.com/newbiumcoin
 - Website: https://coins.newbium.com

--- a/tokens/0x818fc6c2ec5986bc6e2cbf00939d90556ab12ce5.yaml
+++ b/tokens/0x818fc6c2ec5986bc6e2cbf00939d90556ab12ce5.yaml
@@ -5,7 +5,7 @@ description: >-
   Kin by Kik - A decentralized ecosystem of digital services for daily life.
 links:
 - Blog: https://medium.com/kinfoundation
-- CoinMarketCap: kin
+- CoinMarketCap: https://coinmarketcap.com/currencies/kin/
 - Email: mailto:kin@kik.com
 - Github: https://github.com/kikinteractive/kin-token
 - Reddit: https://www.reddit.com/r/KinFoundation

--- a/tokens/0x81c9151de0c8bafcd325a57e3db5a5df1cebf79c.yaml
+++ b/tokens/0x81c9151de0c8bafcd325a57e3db5a5df1cebf79c.yaml
@@ -4,7 +4,7 @@ decimals: 18
 description: >-
   Datum is a global data marketplace that allows you to make money from your own data.
 links:
-- CoinMarketCap: datum
+- CoinMarketCap: https://coinmarketcap.com/currencies/datum/
 - Email: mailto:hello@datum.org
 - Facebook: https://facebook.com/datumnetwork
 - Telegram: https://t.me/datumnetwork

--- a/tokens/0x82b0e50478eeafde392d45d1259ed1071b6fda81.yaml
+++ b/tokens/0x82b0e50478eeafde392d45d1259ed1071b6fda81.yaml
@@ -11,7 +11,7 @@ description: >-
   operates. No other tokens or currencies are accepted. DNA must be used.
 links:
 - Bitcointalk: https://bitcointalk.org/index.php?topic=1968128
-- CoinMarketCap: encrypgen
+- CoinMarketCap: https://coinmarketcap.com/currencies/encrypgen/
 - Email: mailto:drkoepsell@encrypgen.com
 - Facebook: https://www.facebook.com/Encrypgen
 - Github: https://github.com/encrypgen/

--- a/tokens/0x83eea00d838f92dec4d1475697b9f4d3537b56e3.yaml
+++ b/tokens/0x83eea00d838f92dec4d1475697b9f4d3537b56e3.yaml
@@ -7,7 +7,7 @@ description: >-
 links:
 - Bitcointalk: https://bitcointalk.org/index.php?topic=1846376
 - Blog: https://medium.com/@voisecom
-- CoinMarketCap: voisecom
+- CoinMarketCap: https://coinmarketcap.com/currencies/voisecom/
 - Email: mailto:support@voise.com
 - Github: https://github.com/voisecom
 - Reddit: https://www.reddit.com/r/voise/

--- a/tokens/0x84119cb33e8f590d75c2d6ea4e6b0741a7494eda.yaml
+++ b/tokens/0x84119cb33e8f590d75c2d6ea4e6b0741a7494eda.yaml
@@ -7,7 +7,7 @@ description: >-
 links:
 - Bitcointalk: https://bitcointalk.org/index.php?topic=1914900.0
 - Blog: https://medium.com/gigawatt
-- CoinMarketCap: giga-watt-token
+- CoinMarketCap: https://coinmarketcap.com/currencies/giga-watt-token/
 - Email: mailto:support@giga-watt.com
 - Facebook: https://www.facebook.com/gigawattcom/
 - Slack: https://slack.giga-watt.com/

--- a/tokens/0x859a9c0b44cb7066d956a958b0b82e54c9e44b4b.yaml
+++ b/tokens/0x859a9c0b44cb7066d956a958b0b82e54c9e44b4b.yaml
@@ -7,7 +7,7 @@ description: >-
 links:
 - Bitcointalk: https://bitcointalk.org/index.php?topic=2270135
 - Blog: https://medium.com/@maivanhieu
-- CoinMarketCap: iethereum
+- CoinMarketCap: https://coinmarketcap.com/currencies/iethereum/
 - Email: mailto:vitalik@iethereum.trade
 - Github: https://github.com/ethereumfan/iethereum
 - Reddit: https://www.reddit.com/r/iETH/

--- a/tokens/0x86fa049857e0209aa7d9e616f7eb3b3b78ecfdb0.yaml
+++ b/tokens/0x86fa049857e0209aa7d9e616f7eb3b3b78ecfdb0.yaml
@@ -4,7 +4,7 @@ decimals: 18
 description: >-
   The Most Powerful Infrastructure for Decentralized Applications
 links:
-- CoinMarketCap: eos
+- CoinMarketCap: https://coinmarketcap.com/currencies/eos/
 - Email: mailto:eos@block.one
 - Facebook: https://www.facebook.com/eosblockchain
 - Github: https://github.com/eosio

--- a/tokens/0x8727c112c712c4a03371ac87a74dd6ab104af768.yaml
+++ b/tokens/0x8727c112c712c4a03371ac87a74dd6ab104af768.yaml
@@ -4,7 +4,7 @@ decimals: 18
 description: >-
   Jetcoin enables ANYONE to launch the careers of tomorrow&rsquo;s super stars &ndash; the Jetcoin Champions.
 links:
-- CoinMarketCap: jetcoin
+- CoinMarketCap: https://coinmarketcap.com/currencies/jetcoin/
 - Facebook: https://www.facebook.com/jetcoins/
 - Slack: https://jetcoininstitute.slack.com/
 - Twitter: https://twitter.com/jetcoins

--- a/tokens/0x881ef48211982d01e2cb7092c915e647cd40d85c.yaml
+++ b/tokens/0x881ef48211982d01e2cb7092c915e647cd40d85c.yaml
@@ -7,7 +7,7 @@ description: >-
 links:
 - Bitcointalk: https://bitcointalk.org/index.php?topic=2225134
 - Blog: https://medium.com/@otncoin
-- CoinMarketCap: open-trading-network
+- CoinMarketCap: https://coinmarketcap.com/currencies/open-trading-network/
 - Email: mailto:info@otn.org
 - Facebook: https://www.facebook.com/OpenTradingNetwork/
 - Github: https://github.com/OpenTradingNetworkFoundation/otn-token

--- a/tokens/0x888666ca69e0f178ded6d75b5726cee99a87d698.yaml
+++ b/tokens/0x888666ca69e0f178ded6d75b5726cee99a87d698.yaml
@@ -7,7 +7,7 @@ description: >-
   economy.
 links:
 - Blog: https://medium.com/iconominet
-- CoinMarketCap: iconomi
+- CoinMarketCap: https://coinmarketcap.com/currencies/iconomi/
 - Email: mailto:support@iconomi.net
 - Facebook: https://www.facebook.com/iconomi.net/
 - Reddit: https://www.reddit.com/r/ICONOMI

--- a/tokens/0x88fcfbc22c6d3dbaa25af478c578978339bde77a.yaml
+++ b/tokens/0x88fcfbc22c6d3dbaa25af478c578978339bde77a.yaml
@@ -7,7 +7,7 @@ description: >-
   Bitcoin or Ethereum, instead of regular currency.
 links:
 - Blog: https://medium.com/@FundYourselfNow/
-- CoinMarketCap: fundyourselfnow
+- CoinMarketCap: https://coinmarketcap.com/currencies/fundyourselfnow/
 - Email: mailto:contact@fundyourselfnow.com
 - Facebook: https://www.facebook.com/fundyourselfnow/
 - Github: https://github.com/PinnacleOne/FYNTokens

--- a/tokens/0x8aa33a7899fcc8ea5fbe6a608a109c3893a1b8b2.yaml
+++ b/tokens/0x8aa33a7899fcc8ea5fbe6a608a109c3893a1b8b2.yaml
@@ -10,7 +10,7 @@ description: >-
 links:
 - Bitcointalk: https://bitcointalk.org/index.php?action=profile
 - Blog: https://medium.com/@dao.casino/dao-casino-token-sale-campaign-officially-ended-1025d2a853a4
-- CoinMarketCap: dao-casino
+- CoinMarketCap: https://coinmarketcap.com/currencies/dao-casino/
 - Email: mailto:team@dao.casino
 - Facebook: https://www.facebook.com/Dao.casino/
 - Github: https://github.com/daocasino

--- a/tokens/0x8ae4bf2c33a8e667de34b54938b0ccd03eb8cc06.yaml
+++ b/tokens/0x8ae4bf2c33a8e667de34b54938b0ccd03eb8cc06.yaml
@@ -8,7 +8,7 @@ description: >-
 links:
 - Bitcointalk: https://bitcointalk.org/index.php?topic=1886446.0
 - Blog: https://patientory.com/blog/
-- CoinMarketCap: patientory
+- CoinMarketCap: https://coinmarketcap.com/currencies/patientory/
 - Email: mailto:info@patientory.com
 - Facebook: https://www.facebook.com/patientory
 - Slack: https://patientory.slack.com/join/shared_invite/MjIzMTkzMzQ1NzQ4LTE1MDIxMTQxODYtZmFjMjA2MzI4Zg

--- a/tokens/0x8b1f49491477e0fb46a29fef53f1ea320d13c349.yaml
+++ b/tokens/0x8b1f49491477e0fb46a29fef53f1ea320d13c349.yaml
@@ -15,7 +15,7 @@ description: >-
 links:
 - Bitcointalk: https://bitcointalk.org/index.php?topic=2199477.msg22113023#msg22113023
 - Blog: https://medium.com/@micromoney.io
-- CoinMarketCap: micromoney
+- CoinMarketCap: https://coinmarketcap.com/currencies/micromoney/
 - Email: mailto:sales@micromoney.i
 - Facebook: https://www.facebook.com/micromoneymyanmar/
 - Github: https://github.com/micro-money/prime

--- a/tokens/0x8eb24319393716668d768dcec29356ae9cffe285.yaml
+++ b/tokens/0x8eb24319393716668d768dcec29356ae9cffe285.yaml
@@ -5,7 +5,7 @@ description: >-
   SingularityNET is a decentralized marketplace for AI algorithms
 links:
 - Blog: https://blog.singularitynet.io/
-- CoinMarketCap: singularitynet
+- CoinMarketCap: https://coinmarketcap.com/currencies/singularitynet/
 - Email: mailto:info@singularitynet.io
 - Facebook: https://www.facebook.com/singularityNET.io
 - Github: https://github.com/singnet/

--- a/tokens/0x8effd494eb698cc399af6231fccd39e08fd20b15.yaml
+++ b/tokens/0x8effd494eb698cc399af6231fccd39e08fd20b15.yaml
@@ -9,7 +9,7 @@ description: >-
   will use PIX tokens to grow the data ecosystem through purchases and payments.
 links:
 - Blog: https://medium.com/@lampix
-- CoinMarketCap: lampix
+- CoinMarketCap: https://coinmarketcap.com/currencies/lampix/
 - Email: mailto:support@lampix.co
 - Facebook: https://www.facebook.com/Lampix-997463780290920/
 - Reddit: https://www.reddit.com/r/Lampix/

--- a/tokens/0x8f3470a7388c05ee4e7af3d01d8c722b0ff52374.yaml
+++ b/tokens/0x8f3470a7388c05ee4e7af3d01d8c722b0ff52374.yaml
@@ -5,7 +5,7 @@ description: >-
   Veritaseum enables software-driven P2P capital markets without brokerages, banks or traditional exchanges
 links:
 - Blog: http://veritas.veritaseum.com/index.php/blog
-- CoinMarketCap: Veritaseum
+- CoinMarketCap: https://coinmarketcap.com/currencies/Veritaseum/
 - Email: mailto:reggie@veritaseum.com
 - Facebook: https://www.facebook.com/reggiemiddletonfintech/
 - Twitter: https://twitter.com/ReggieMiddleton

--- a/tokens/0x8f8221afbb33998d8584a2b05749ba73c37a938a.yaml
+++ b/tokens/0x8f8221afbb33998d8584a2b05749ba73c37a938a.yaml
@@ -6,7 +6,7 @@ description: >-
 links:
 - Bitcointalk: https://bitcointalk.org/index.php?topic=2137740.0
 - Blog: https://blog.request.network/
-- CoinMarketCap: request-network
+- CoinMarketCap: https://coinmarketcap.com/currencies/request-network/
 - Facebook: https://www.facebook.com/TheRequestNetwork/
 - Github: https://github.com/RequestNetwork/
 - Reddit: https://www.reddit.com/r/RequestNetwork/

--- a/tokens/0x9002d4485b7594e3e850f0a206713b305113f69e.yaml
+++ b/tokens/0x9002d4485b7594e3e850f0a206713b305113f69e.yaml
@@ -7,7 +7,7 @@ description: >-
 links:
 - Bitcointalk: https://bitcointalk.org/index.php?topic=2285591.0
 - Blog: https://www.hawala.today/blog/
-- CoinMarketCap: hawala-today
+- CoinMarketCap: https://coinmarketcap.com/currencies/hawala-today/
 - Email: mailto:info@hawala.today
 - Facebook: https://www.facebook.com/hawalatoday
 - Reddit: https://www.reddit.com/r/HawalaToday/

--- a/tokens/0x9214ec02cb71cba0ada6896b8da260736a67ab10.yaml
+++ b/tokens/0x9214ec02cb71cba0ada6896b8da260736a67ab10.yaml
@@ -9,7 +9,7 @@ description: >-
   (RPP) on our platform.
 links:
 - Blog: https://medium.com/@real_token/
-- CoinMarketCap: real
+- CoinMarketCap: https://coinmarketcap.com/currencies/real/
 - Email: mailto:info@real.markets
 - Facebook: https://www.facebook.com/realestateassetledger
 - Github: https://github.com/RealEstateAssetLedger/real_contract

--- a/tokens/0x93e682107d1e9defb0b5ee701c71707a4b2e46bc.yaml
+++ b/tokens/0x93e682107d1e9defb0b5ee701c71707a4b2e46bc.yaml
@@ -8,7 +8,7 @@ description: >-
   will be recorded to the Ethereum Blockchain to ensure immutability and transparency.
 links:
 - Blog: https://medium.com/mcap-labs
-- CoinMarketCap: mcap
+- CoinMarketCap: https://coinmarketcap.com/currencies/mcap/
 - Facebook: https://www.facebook.com/MCAPlabs/
 - Twitter: https://twitter.com/MCAPlabs
 - Website: http://mcaplabs.com/

--- a/tokens/0x957c30ab0426e0c93cd8241e2c60392d08c6ac8e.yaml
+++ b/tokens/0x957c30ab0426e0c93cd8241e2c60392d08c6ac8e.yaml
@@ -6,7 +6,7 @@ description: >-
   of physical products, streamlining supply chain processes in many sectors.
 links:
 - Blog: https://modum.io/news/news/
-- CoinMarketCap: modum
+- CoinMarketCap: https://coinmarketcap.com/currencies/modum/
 - Email: mailto:info@modum.io
 - Github: https://github.com/modum-io
 - Reddit: https://www.reddit.com/r/modum_io/

--- a/tokens/0x960b236a07cf122663c4303350609a66a7b288c0.yaml
+++ b/tokens/0x960b236a07cf122663c4303350609a66a7b288c0.yaml
@@ -6,7 +6,7 @@ description: >-
   it extremely easy and friendly for organizations, entrepreneurs and investors to operate.
 links:
 - Blog: https://blog.aragon.one/
-- CoinMarketCap: aragon
+- CoinMarketCap: https://coinmarketcap.com/currencies/aragon/
 - Email: mailto:founders@aragon.one
 - Website: https://aragon.network/
 - Website: https://aragon.one/

--- a/tokens/0x96a65609a7b84e8842732deb08f56c3e21ac6f8a.yaml
+++ b/tokens/0x96a65609a7b84e8842732deb08f56c3e21ac6f8a.yaml
@@ -9,7 +9,7 @@ description: >-
 links:
 - Bitcointalk: https://bitcointalk.org/index.php?topic=2114806
 - Blog: https://www.medium.com/@Centra
-- CoinMarketCap: centra
+- CoinMarketCap: https://coinmarketcap.com/currencies/centra/
 - Email: mailto:support@centra.tech
 - Facebook: http://www.facebook.com/CentraCard
 - Github: https://github.com/CentraTech/smart-contract

--- a/tokens/0x983f6d60db79ea8ca4eb9968c6aff8cfa04b3c63.yaml
+++ b/tokens/0x983f6d60db79ea8ca4eb9968c6aff8cfa04b3c63.yaml
@@ -7,7 +7,7 @@ description: >-
 links:
 - Bitcointalk: http://a.sonm.io/bitcointalk
 - Blog: https://blog.sonm.io/
-- CoinMarketCap: sonm
+- CoinMarketCap: https://coinmarketcap.com/currencies/sonm/
 - Email: mailto:support@sonm.io
 - Facebook: http://a.sonm.io/facebook
 - Github: http://a.sonm.io/github

--- a/tokens/0x99ea4db9ee77acd40b119bd1dc4e33e1c070b80d.yaml
+++ b/tokens/0x99ea4db9ee77acd40b119bd1dc4e33e1c070b80d.yaml
@@ -5,7 +5,7 @@ description: >-
   Quantstamp: The Protocol for Securing Smart Contracts
 links:
 - Blog: https://medium.com/quantstamp
-- CoinMarketCap: quantstamp
+- CoinMarketCap: https://coinmarketcap.com/currencies/quantstamp/
 - Facebook: https://www.facebook.com/quantstamp/
 - Github: https://github.com/quantstamp
 - Reddit: https://www.reddit.com/r/Quantstamp/

--- a/tokens/0x9af4f26941677c706cfecf6d3379ff01bb85d5ab.yaml
+++ b/tokens/0x9af4f26941677c706cfecf6d3379ff01bb85d5ab.yaml
@@ -10,7 +10,7 @@ description: >-
   be able to join the network, provide their services and add value to the blockchain.
 links:
 - Blog: https://medium.com/@domraider
-- CoinMarketCap: domraider
+- CoinMarketCap: https://coinmarketcap.com/currencies/domraider/
 - Email: mailto:support-fr@domraider.com
 - Facebook: https://www.facebook.com/Domraider-1432606216988548
 - Github: https://github.com/Domraider/dr-token

--- a/tokens/0x9b11efcaaa1890f6ee52c6bb7cf8153ac5d74139.yaml
+++ b/tokens/0x9b11efcaaa1890f6ee52c6bb7cf8153ac5d74139.yaml
@@ -9,7 +9,7 @@ description: >-
   trading system with free access to advertising, which is a system that combines block chain network
   and the platform of ATMChain as well as advertising distribution channel.
 links:
-- CoinMarketCap: attention-token-of-media
+- CoinMarketCap: https://coinmarketcap.com/currencies/attention-token-of-media/
 - Email: mailto:dev@atmchain.io
 - Github: https://github.com/ATMChain
 - Twitter: https://twitter.com/ATMChainDev

--- a/tokens/0x9c23d67aea7b95d80942e3836bcdf7e708a747c2.yaml
+++ b/tokens/0x9c23d67aea7b95d80942e3836bcdf7e708a747c2.yaml
@@ -8,7 +8,7 @@ description: >-
 links:
 - Bitcointalk: https://bitcointalk.org/index.php?topic=2161880
 - Blog: https://medium.com/@John_Loci
-- CoinMarketCap: https://coinmarketcap.com/currencies/locicoin
+- CoinMarketCap: https://coinmarketcap.com/currencies/locicoin/
 - Email: mailto:info@loci.io
 - Facebook: https://www.facebook.com/Loci.InnVenn/
 - Github: https://github.com/Locipro

--- a/tokens/0x9e77d5a1251b6f7d456722a6eac6d2d5980bd891.yaml
+++ b/tokens/0x9e77d5a1251b6f7d456722a6eac6d2d5980bd891.yaml
@@ -5,7 +5,7 @@ description: >-
   Use your own kinsman, yard serf
 links:
 - Bitcointalk: https://bitcointalk.org/index.php?topic=2024699.0
-- CoinMarketCap: brat
+- CoinMarketCap: https://coinmarketcap.com/currencies/brat/
 - Email: mailto:info@brat.red
 - Telegram: https://t.me/icobrat
 - Website: http://www.brat.red/

--- a/tokens/0x9f8f72aa9304c8b593d555f12ef6589cc3a579a2.yaml
+++ b/tokens/0x9f8f72aa9304c8b593d555f12ef6589cc3a579a2.yaml
@@ -6,7 +6,7 @@ description: >-
   Ethereum blockchain.
 links:
 - Blog: https://blog.makerdao.com/
-- CoinMarketCap: maker
+- CoinMarketCap: https://coinmarketcap.com/currencies/maker/
 - Reddit: https://www.reddit.com/r/MakerDAO/
 - Slack: https://chat.makerdao.com/
 - Website: https://makerdao.com/

--- a/tokens/0xa54ddc7b3cce7fc8b1e3fa0256d0db80d2c10970.yaml
+++ b/tokens/0xa54ddc7b3cce7fc8b1e3fa0256d0db80d2c10970.yaml
@@ -4,7 +4,7 @@ decimals: 18
 description: >-
   A driving force behind the GNP of a real cash virtual goods economy.
 links:
-- CoinMarketCap: neverdie
+- CoinMarketCap: https://coinmarketcap.com/currencies/neverdie/
 - Website: https://neverdie.com
 name: NEVERDIE
 symbol: NDC

--- a/tokens/0xa645264c5603e96c3b0b078cdab68733794b0a71.yaml
+++ b/tokens/0xa645264c5603e96c3b0b078cdab68733794b0a71.yaml
@@ -5,7 +5,7 @@ description: >-
   Mysterium foundation is developing Mysterium Network &ndash; an Open source software, powering a Decentralized
   Network of VPN Nodes.
 links:
-- CoinMarketCap: mysterium
+- CoinMarketCap: https://coinmarketcap.com/currencies/mysterium/
 - Website: https://mysterium.network
 - Website: https://mysterium.network/
 name: Mysterium

--- a/tokens/0xa7f976c360ebbed4465c2855684d1aae5271efa9.yaml
+++ b/tokens/0xa7f976c360ebbed4465c2855684d1aae5271efa9.yaml
@@ -6,7 +6,7 @@ description: >-
 links:
 - Bitcointalk: https://bitcointalk.org/index.php?topic=1928663.60
 - Blog: https://steemit.com/@trueflip
-- CoinMarketCap: trueflip
+- CoinMarketCap: https://coinmarketcap.com/currencies/trueflip/
 - Email: mailto:info@trueflip.io
 - Facebook: https://www.facebook.com/TrueFlip.io/
 - Github: https://github.com/TrueFlip

--- a/tokens/0xa8006c4ca56f24d6836727d106349320db7fef82.yaml
+++ b/tokens/0xa8006c4ca56f24d6836727d106349320db7fef82.yaml
@@ -4,7 +4,7 @@ decimals: 8
 description: >-
   Internxt, a simple, more private and secure decentralized cloud for files, apps and websites.
 links:
-- CoinMarketCap: internxt
+- CoinMarketCap: https://coinmarketcap.com/currencies/internxt/
 - Email: mailto:hello@internxt.io
 - Github: https://github.com/internxt
 - Telegram: https://t.me/internxt_io

--- a/tokens/0xa823e6722006afe99e91c30ff5295052fe6b8e32.yaml
+++ b/tokens/0xa823e6722006afe99e91c30ff5295052fe6b8e32.yaml
@@ -6,7 +6,7 @@ description: >-
 links:
 - Bitcointalk: https://bitcointalk.org/index.php?topic=2335433
 - Blog: https://blog.neufund.org/
-- CoinMarketCap: neumark
+- CoinMarketCap: https://coinmarketcap.com/currencies/neumark/
 - Email: mailto:services@neufund.org
 - Facebook: https://www.facebook.com/neufundorg/
 - Github: https://github.com/Neufund/

--- a/tokens/0xaaaf91d9b90df800df4f55c205fd6989c977e73a.yaml
+++ b/tokens/0xaaaf91d9b90df800df4f55c205fd6989c977e73a.yaml
@@ -5,7 +5,7 @@ description: >-
   TKN is the underlying token of the TokenCard platform.
 links:
 - Blog: https://medium.com/@MonolithStudio
-- CoinMarketCap: tokencard
+- CoinMarketCap: https://coinmarketcap.com/currencies/tokencard/
 - Email: mailto:hello@tokencard.io
 - Twitter: https://twitter.com/monolith_web3
 - Website: https://tokencard.io/#token

--- a/tokens/0xab95e915c123fded5bdfb6325e35ef5515f1ea69.yaml
+++ b/tokens/0xab95e915c123fded5bdfb6325e35ef5515f1ea69.yaml
@@ -4,7 +4,7 @@ decimals: 18
 description: >-
   An alternative implementation of the EOS project with widespread, non-ICO'd token distribution.
 links:
-- CoinMarketCap: xenon
+- CoinMarketCap: https://coinmarketcap.com/currencies/xenon/
 - Email: mailto:contact@xenon.network
 - Slack: https://join.slack.com/t/xenonnetwork/shared_invite/enQtMjQ1NzQ2MTQ1OTA2LWI5MjkzZWQxNzRmYzNmOGE5Nzc2MWYyN2NjM2Y2MTZjNjA2MDUyNmI5ZGFkNjU3YzE5NGVjNjA0YzkzMDk5ZGU
 - Twitter: https://twitter.com/XenonNet

--- a/tokens/0xac3da587eac229c9896d919abc235ca4fd7f72c1.yaml
+++ b/tokens/0xac3da587eac229c9896d919abc235ca4fd7f72c1.yaml
@@ -6,7 +6,7 @@ description: >-
 links:
 - Bitcointalk: https://bitcointalk.org/index.php?topic=1997376.0
 - Blog: https://medium.com/@TargetCoin/
-- CoinMarketCap: target-coin
+- CoinMarketCap: https://coinmarketcap.com/currencies/target-coin/
 - Facebook: https://www.facebook.com/targetcoinfund/
 - Telegram: https://t.me/joinchat/FJeVV0HwLpRAZB9MyJI0lQ
 - Twitter: https://twitter.com/TargetCoin

--- a/tokens/0xac709fcb44a43c35f0da4e3163b117a17f3770f5.yaml
+++ b/tokens/0xac709fcb44a43c35f0da4e3163b117a17f3770f5.yaml
@@ -10,7 +10,7 @@ description: >-
   development, platform cooperativism, and a decentralized &lsquo;swarm&rsquo; organizational model open
   to all.
 links:
-- CoinMarketCap: arcade-token
+- CoinMarketCap: https://coinmarketcap.com/currencies/arcade-token/
 - Facebook: https://www.facebook.com/ArcadeCityHall
 - Twitter: https://twitter.com/ArcadeCityHall
 - Website: https://arcade.city/

--- a/tokens/0xae616e72d3d89e847f74e8ace41ca68bbf56af79.yaml
+++ b/tokens/0xae616e72d3d89e847f74e8ace41ca68bbf56af79.yaml
@@ -14,7 +14,7 @@ description: >-
   powered by Good Karma.​
 links:
 - Bitcointalk: https://bitcointalk.org/index.php?topic=1969334.0
-- CoinMarketCap: good-karma
+- CoinMarketCap: https://coinmarketcap.com/currencies/good-karma/
 - Facebook: https://www.facebook.com/GoodKarmaCoin/
 - Twitter: https://twitter.com/GoodKarmaCoin
 - Website: http://goodomy.com/

--- a/tokens/0xaec2e87e0a235266d9c5adc9deb4b2e29b54d009.yaml
+++ b/tokens/0xaec2e87e0a235266d9c5adc9deb4b2e29b54d009.yaml
@@ -6,7 +6,7 @@ description: >-
 links:
 - Bitcointalk: https://bitcointalk.org/index.php?topic=1943123.0
 - Blog: https://medium.com/@SingularDTV
-- CoinMarketCap: singulardtv
+- CoinMarketCap: https://coinmarketcap.com/currencies/singulardtv/
 - Email: https://singulardtv.com/contact-us
 - Facebook: https://www.facebook.com/SingularDTV/
 - Reddit: https://www.reddit.com/r/SingularDTV

--- a/tokens/0xaf30d2a7e90d7dc361c8c4585e9bb7d2f6f15bc7.yaml
+++ b/tokens/0xaf30d2a7e90d7dc361c8c4585e9bb7d2f6f15bc7.yaml
@@ -7,7 +7,7 @@ description: >-
   of Legends, Dota 2, and Counter-Strike: Global Offensive.
 links:
 - Bitcointalk: https://bitcointalk.org/index.php?topic=1543891.0
-- CoinMarketCap: firstblood
+- CoinMarketCap: https://coinmarketcap.com/currencies/firstblood/
 - Email: mailto:team@firstblood.io
 - Facebook: https://www.facebook.com/firstbloodio
 - Github: https://github.com/firstbloodio

--- a/tokens/0xaf4dce16da2877f8c9e00544c93b62ac40631f16.yaml
+++ b/tokens/0xaf4dce16da2877f8c9e00544c93b62ac40631f16.yaml
@@ -7,7 +7,7 @@ description: >-
 links:
 - Bitcointalk: https://bitcointalk.org/index.php?topic=1978067.0
 - Blog: https://blog.monetha.io/
-- CoinMarketCap: monetha
+- CoinMarketCap: https://coinmarketcap.com/currencies/monetha/
 - Email: mailto:team@monetha.io
 - Facebook: https://www.facebook.com/Monetha.io
 - Github: https://github.com/monetha

--- a/tokens/0xafc39788c51f0c1ff7b55317f3e70299e521fff6.yaml
+++ b/tokens/0xafc39788c51f0c1ff7b55317f3e70299e521fff6.yaml
@@ -6,7 +6,7 @@ description: >-
   eBCh is a tokenized version of BitcoinCash on the Ethereum blockchain
 links:
 - Bitcointalk: https://bitcointalk.org/index.php?topic=2432836.msg24914103#msg24914103
-- CoinMarketCap: ebitcoin-cash
+- CoinMarketCap: https://coinmarketcap.com/currencies/ebitcoin-cash/
 - Email: mailto:team@ebitcoincash.io
 - Facebook: https://www.facebook.com/eBCHCoin-1528769833904071/
 - Reddit: https://www.reddit.com/user/eBCHCoin/

--- a/tokens/0xb24754be79281553dc1adc160ddf5cd9b74361a4.yaml
+++ b/tokens/0xb24754be79281553dc1adc160ddf5cd9b74361a4.yaml
@@ -8,7 +8,7 @@ description: >-
   transaction.
 links:
 - Blog: https://medium.com/@RialtoAI/
-- CoinMarketCap: rialto
+- CoinMarketCap: https://coinmarketcap.com/currencies/rialto/
 - Facebook: https://www.facebook.com/RIALTOAI-1908809969366651/
 - Slack: http://www.rialto.ai/slack
 - Twitter: https://twitter.com/RialtoAI

--- a/tokens/0xb2f7eb1f2c37645be61d73953035360e768d81e6.yaml
+++ b/tokens/0xb2f7eb1f2c37645be61d73953035360e768d81e6.yaml
@@ -5,7 +5,7 @@ description: >-
   CRYPTOCURRENCY EXCHANGE
 links:
 - Blog: https://medium.com/@cobinhoodblog
-- CoinMarketCap: cobinhood
+- CoinMarketCap: https://coinmarketcap.com/currencies/cobinhood/
 - Email: mailto:support@cobinhood.com
 - Github: https://github.com/cobinhood
 - Slack: http://slack.cobinhood.com/

--- a/tokens/0xb3bd49e28f8f832b8d1e246106991e546c323502.yaml
+++ b/tokens/0xb3bd49e28f8f832b8d1e246106991e546c323502.yaml
@@ -5,7 +5,7 @@ description: >-
   The Future of Communication Platforms Built on the Ethereum Blockchain
 links:
 - Blog: https://medium.com/mercuryprotocol
-- CoinMarketCap: mercury-protocol
+- CoinMarketCap: https://coinmarketcap.com/currencies/mercury-protocol/
 - Email: mailto:info@mercuryprotocol.com
 - Reddit: https://www.reddit.com/r/MercuryProtocol/
 - Slack: https://mercuryprotocol.slack.com/

--- a/tokens/0xb45a50545beeab73f38f31e5973768c421805e5e.yaml
+++ b/tokens/0xb45a50545beeab73f38f31e5973768c421805e5e.yaml
@@ -10,7 +10,7 @@ description: >-
 links:
 - Bitcointalk: https://bitcointalk.org/index.php?topic=2046549
 - Blog: https://medium.com/@trackr.im/
-- CoinMarketCap: trackr
+- CoinMarketCap: https://coinmarketcap.com/currencies/trackr/
 - Email: mailto:team@trackr.im
 - Facebook: https://www.facebook.com/trackrim/
 - Github: https://github.com/trackr-im

--- a/tokens/0xb53a96bcbdd9cf78dff20bab6c2be7baec8f00f8.yaml
+++ b/tokens/0xb53a96bcbdd9cf78dff20bab6c2be7baec8f00f8.yaml
@@ -7,7 +7,7 @@ description: >-
 links:
 - Bitcointalk: https://bitcointalk.org/index.php?topic=2328682
 - Blog: https://medium.com/@eth_gas
-- CoinMarketCap: ethgas
+- CoinMarketCap: https://coinmarketcap.com/currencies/ethgas/
 - Email: mailto:egas@ethgas.stream
 - Facebook: https://www.facebook.com/ethgas/
 - Slack: https://ethgas.slack.com/

--- a/tokens/0xb5a5f22694352c15b00323844ad545abb2b11028.yaml
+++ b/tokens/0xb5a5f22694352c15b00323844ad545abb2b11028.yaml
@@ -8,7 +8,7 @@ description: >-
 links:
 - Bitcointalk: https://bitcointalk.org/index.php?topic=2115503.0
 - Blog: https://medium.com/helloiconworld
-- CoinMarketCap: icon
+- CoinMarketCap: https://coinmarketcap.com/currencies/icon/
 - Email: mailto:hello@icon.foundation
 - Facebook: https://www.facebook.com/helloicon
 - Github: https://github.com/theloopkr/loopchain

--- a/tokens/0xb62d18dea74045e822352ce4b3ee77319dc5ff2f.yaml
+++ b/tokens/0xb62d18dea74045e822352ce4b3ee77319dc5ff2f.yaml
@@ -10,7 +10,7 @@ description: >-
 links:
 - Bitcointalk: https://bitcointalk.org/index.php?topic=1978714
 - Blog: https://blog.eventchain.io/
-- CoinMarketCap: eventchain
+- CoinMarketCap: https://coinmarketcap.com/currencies/eventchain/
 - Email: mailto:team@eventchain.io
 - Facebook: https://www.facebook.com/EventChain
 - Slack: https://join.slack.com/t/eventchain/shared_invite/MjI5MTYyMzg2OTMyLTE1MDMyNDEwMzEtZWJmNjFlZmQxYQ

--- a/tokens/0xb63b606ac810a52cca15e44bb630fd42d8d1d83d.yaml
+++ b/tokens/0xb63b606ac810a52cca15e44bb630fd42d8d1d83d.yaml
@@ -5,7 +5,7 @@ description: >-
   Introducing Monaco - world's best cryptocurrency card. Spend and send money globally at perfect interbank
   exchange rates, saving EUR30-40 on every EUR500 equivalent spent.
 links:
-- CoinMarketCap: monaco
+- CoinMarketCap: https://coinmarketcap.com/currencies/monaco/
 - Facebook: https://www.facebook.com/Monaco-Card-1355426087883151/
 - Slack: https://slack.mona.co/
 - Telegram: https://t.me/MonacoCard

--- a/tokens/0xb64ef51c888972c908cfacf59b47c1afbc0ab8ac.yaml
+++ b/tokens/0xb64ef51c888972c908cfacf59b47c1afbc0ab8ac.yaml
@@ -5,7 +5,7 @@ description: >-
   Blockchain-based, end-to-end encrypted, distributed object storage.
 links:
 - Blog: https://medium.com/@storjproject
-- CoinMarketCap: storj
+- CoinMarketCap: https://coinmarketcap.com/currencies/storj/
 - Email: https://storj.io/contact.html
 - Facebook: https://www.facebook.com/storjproject
 - Github: https://github.com/Storj/

--- a/tokens/0xb7cb1c96db6b22b0d3d9536e0108d062bd488f74.yaml
+++ b/tokens/0xb7cb1c96db6b22b0d3d9536e0108d062bd488f74.yaml
@@ -5,7 +5,7 @@ description: >-
   Blockchain + RFID
 links:
 - Blog: http://blog.sina.com.cn/u/6277713943
-- CoinMarketCap: walton
+- CoinMarketCap: https://coinmarketcap.com/currencies/walton/
 - Email: mailto:services@waltonchain.org
 - Website: http://www.waltonchain.org/
 - Whitepaper: http://www.waltonchain.org/upload/1498826072890.pdf

--- a/tokens/0xb802b24e0637c2b87d2e8b7784c055bbe921011a.yaml
+++ b/tokens/0xb802b24e0637c2b87d2e8b7784c055bbe921011a.yaml
@@ -12,7 +12,7 @@ description: >-
 
   Fosters the daily use of Ethereum and tests new Ethereum use-cases
 links:
-- CoinMarketCap: ethereum-movie-venture
+- CoinMarketCap: https://coinmarketcap.com/currencies/ethereum-movie-venture/
 - Email: mailto:mail@akenevilthing.com
 - Facebook: https://www.facebook.com/ThePittsCircus
 - Twitter: https://twitter.com/pitts_circus

--- a/tokens/0xb8c77482e45f1f44de1745f52c74426c631bdd52.yaml
+++ b/tokens/0xb8c77482e45f1f44de1745f52c74426c631bdd52.yaml
@@ -4,7 +4,7 @@ decimals: 18
 description: >-
   币安交易平台是由赵长鹏（CZ）领导的一群数字资产爱好者创建而成的一个专注区块链资产的交易平台。为用户提供更加安全、便捷的数字货币兑换服务，聚合全球优质数字货币，致力于打造世界级的区块链资产交易平台。
 links:
-- CoinMarketCap: binance-coin
+- CoinMarketCap: https://coinmarketcap.com/currencies/binance-coin/
 - Email: mailto:support@binance.zendesk.com
 - Facebook: https://www.facebook.com/binance2017/
 - Reddit: https://www.reddit.com/r/binance/

--- a/tokens/0xb91318f35bdb262e9423bc7c7c2a3a93dd93c92c.yaml
+++ b/tokens/0xb91318f35bdb262e9423bc7c7c2a3a93dd93c92c.yaml
@@ -6,7 +6,7 @@ description: >-
   enables companies to deploy a Customized block chain to meet a set of requirements.
 links:
 - Blog: https://steemit.com/@nuls
-- CoinMarketCap: nuls
+- CoinMarketCap: https://coinmarketcap.com/currencies/nuls/
 - Email: mailto:hi@nuls.io
 - Facebook: https://www.facebook.com/nul.ben.71
 - Github: https://github.com/nuls-io/nuls

--- a/tokens/0xb97048628db6b661d4c2aa833e95dbe1a905b280.yaml
+++ b/tokens/0xb97048628db6b661d4c2aa833e95dbe1a905b280.yaml
@@ -7,7 +7,7 @@ description: >-
 links:
 - Bitcointalk: https://bitcointalk.org/index.php?topic=1953612.0
 - Blog: https://medium.com/tenx-wallet
-- CoinMarketCap: tenx
+- CoinMarketCap: https://coinmarketcap.com/currencies/tenx/
 - Email: mailto:team@tenx.tech
 - Facebook: https://www.facebook.com/tenxwallet/
 - Reddit: https://www.reddit.com/r/TenX/

--- a/tokens/0xb9e7f8568e08d5659f5d29c4997173d84cdf2607.yaml
+++ b/tokens/0xb9e7f8568e08d5659f5d29c4997173d84cdf2607.yaml
@@ -6,7 +6,7 @@ description: >-
   team that focuses on your interests and connect!
 links:
 - Blog: https://medium.com/swarm-city-times
-- CoinMarketCap: swarm-city
+- CoinMarketCap: https://coinmarketcap.com/currencies/swarm-city/
 - Facebook: https://www.facebook.com/groups/SwarmCity/
 - Github: https://github.com/swarmcity
 - Reddit: https://www.reddit.com/r/SwarmCity/

--- a/tokens/0xba2184520a1cc49a6159c57e61e1844e085615b6.yaml
+++ b/tokens/0xba2184520a1cc49a6159c57e61e1844e085615b6.yaml
@@ -9,7 +9,7 @@ description: >-
   across the world.
 links:
 - Blog: https://medium.com/hellogold
-- CoinMarketCap: hellogold
+- CoinMarketCap: https://coinmarketcap.com/currencies/hellogold/
 - Email: mailto:foundation@hellogold.org
 - Github: https://github.com/myHelloGold/Foundation
 - Reddit: https://www.reddit.com/r/HelloGold/

--- a/tokens/0xba5f11b16b155792cf3b2e6880e8706859a8aeb6.yaml
+++ b/tokens/0xba5f11b16b155792cf3b2e6880e8706859a8aeb6.yaml
@@ -9,7 +9,7 @@ description: >-
 links:
 - Bitcointalk: https://bitcointalk.org/index.php?topic=2078239.0
 - Blog: https://medium.com/@aeronaero
-- CoinMarketCap: aeron
+- CoinMarketCap: https://coinmarketcap.com/currencies/aeron/
 - Email: mailto:info@aeron.aero
 - Facebook: https://www.facebook.com/aeronpublic/
 - Github: https://github.com/aeronaero/aeron

--- a/tokens/0xbc86727e770de68b1060c91f6bb6945c73e10388.yaml
+++ b/tokens/0xbc86727e770de68b1060c91f6bb6945c73e10388.yaml
@@ -14,7 +14,7 @@ description: >-
 links:
 - Bitcointalk: https://bitcointalk.org/index.php?topic=2410199
 - Blog: https://medium.com/@PayWithInk
-- CoinMarketCap: https://coinmarketcap.com/currencies/ink-protocol
+- CoinMarketCap: https://coinmarketcap.com/currencies/ink-protocol/
 - Github: https://github.com/InkProtocol/contracts
 - Reddit: https://www.reddit.com/r/PayWithInk/
 - Telegram: https://t.me/paywithink

--- a/tokens/0xbdc5bac39dbe132b1e030e898ae3830017d7d969.yaml
+++ b/tokens/0xbdc5bac39dbe132b1e030e898ae3830017d7d969.yaml
@@ -8,7 +8,7 @@ description: >-
 links:
 - Bitcointalk: https://bitcointalk.org/index.php?topic=2111272.0
 - Blog: https://snov.io/blog/
-- CoinMarketCap: snovio
+- CoinMarketCap: https://coinmarketcap.com/currencies/snovio/
 - Email: mailto:ico@snov.io
 - Facebook: https://www.facebook.com/Snovio-ICO-147118702534568/
 - Reddit: https://www.reddit.com/user/Snovio_ICO/

--- a/tokens/0xbeb9ef514a379b997e0798fdcc901ee474b6d9a1.yaml
+++ b/tokens/0xbeb9ef514a379b997e0798fdcc901ee474b6d9a1.yaml
@@ -8,7 +8,7 @@ description: >-
   manner.
 links:
 - Blog: https://medium.com/melonport-blog
-- CoinMarketCap: melon
+- CoinMarketCap: https://coinmarketcap.com/currencies/melon/
 - Email: mailto:team@melonport.com
 - Github: https://github.com/melonproject
 - Reddit: https://www.reddit.com/r/melonproject/

--- a/tokens/0xbf2179859fc6d5bee9bf9158632dc51678a4100e.yaml
+++ b/tokens/0xbf2179859fc6d5bee9bf9158632dc51678a4100e.yaml
@@ -17,7 +17,7 @@ description: >-
   system and other major decisions.
 links:
 - Blog: https://medium.com/@aelfblockchain
-- CoinMarketCap: aelf
+- CoinMarketCap: https://coinmarketcap.com/currencies/aelf/
 - Email: mailto:contact@aelf.io
 - Facebook: https://www.facebook.com/grid.blockchain.1
 - Github: https://github.com/aelfProject

--- a/tokens/0xc0c2ee1ce1fed8f6e2764363a36db3dd4cf10022.yaml
+++ b/tokens/0xc0c2ee1ce1fed8f6e2764363a36db3dd4cf10022.yaml
@@ -7,7 +7,7 @@ description: >-
   for everyone while providing utmost security &amp; privacy to our users.
 links:
 - Bitcointalk: https://bitcointalk.org/index.php?topic=2376452.0
-- CoinMarketCap: faceblock
+- CoinMarketCap: https://coinmarketcap.com/currencies/faceblock/
 - Email: mailto:team@faceblock.io
 - Twitter: https://twitter.com/thefaceblock
 - Website: https://faceblock.io/

--- a/tokens/0xc0eb85285d83217cd7c891702bcbc0fc401e2d9d.yaml
+++ b/tokens/0xc0eb85285d83217cd7c891702bcbc0fc401e2d9d.yaml
@@ -12,7 +12,7 @@ description: >-
 links:
 - Bitcointalk: https://bitcointalk.org/index.php?topic=1959159.0
 - Blog: https://medium.com/hiveproject-net
-- CoinMarketCap: hive
+- CoinMarketCap: https://coinmarketcap.com/currencies/hive/
 - Email: mailto:info@hive-project.net
 - Facebook: https://www.facebook.com/HiveProject.net/
 - Github: https://github.com/HiveProjectLtd

--- a/tokens/0xc27a2f05fa577a83ba0fdb4c38443c0718356501.yaml
+++ b/tokens/0xc27a2f05fa577a83ba0fdb4c38443c0718356501.yaml
@@ -7,7 +7,7 @@ description: >-
 links:
 - Bitcointalk: https://bitcointalk.org/index.php?topic=2338211.msg23792974
 - Blog: https://blog.lamden.io/
-- CoinMarketCap: lamden
+- CoinMarketCap: https://coinmarketcap.com/currencies/lamden/
 - Email: mailto:team@lamden.io
 - Facebook: https://www.facebook.com/LamdenTau/
 - Github: https://github.com/Lamden/

--- a/tokens/0xc324a2f6b05880503444451b8b27e6f9e63287cb.yaml
+++ b/tokens/0xc324a2f6b05880503444451b8b27e6f9e63287cb.yaml
@@ -5,7 +5,7 @@ description: >-
   XUC is a digital asset, similar to Ripple's XRP. It is optimized for real-time trades between digital
   asset exchanges and serves as fuel for each trade.
 links:
-- CoinMarketCap: exchange-union
+- CoinMarketCap: https://coinmarketcap.com/currencies/exchange-union/
 - Facebook: https://www.facebook.com/ExchangeUnion/
 - Reddit: https://www.reddit.com/r/ExchangeUnion/
 - Slack: https://exchange-union.slack.com/

--- a/tokens/0xc3951d77737733174152532e8b0f27e2c4e9f0dc.yaml
+++ b/tokens/0xc3951d77737733174152532e8b0f27e2c4e9f0dc.yaml
@@ -5,7 +5,7 @@ description: >-
   Basic Amazon Web Services for $1 USD per month!  Offer available for Cloud Token payments only.
 links:
 - Blog: https://cloudwith.me/blog
-- CoinMarketCap: cloud
+- CoinMarketCap: https://coinmarketcap.com/currencies/cloud/
 - Email: mailto:info@cloudwith.me
 - Facebook: https://www.facebook.com/cloudwithme/
 - Github: https://gist.github.com/cwmdev/a72fe06869d1296c10458df8b51b2d20

--- a/tokens/0xc42209accc14029c1012fb5680d95fbd6036e2a0.yaml
+++ b/tokens/0xc42209accc14029c1012fb5680d95fbd6036e2a0.yaml
@@ -7,7 +7,7 @@ description: >-
 links:
 - Bitcointalk: https://bitcointalk.org/index.php?topic=2061671
 - Blog: https://blog.paypie.com/
-- CoinMarketCap: paypie
+- CoinMarketCap: https://coinmarketcap.com/currencies/paypie/
 - Email: mailto:help@paypie.com
 - Facebook: https://www.facebook.com/PayPiePlatform
 - Reddit: https://www.reddit.com/r/PayPie/

--- a/tokens/0xc8c6a31a4a806d3710a7b38b7b296d2fabccdba8.yaml
+++ b/tokens/0xc8c6a31a4a806d3710a7b38b7b296d2fabccdba8.yaml
@@ -5,7 +5,7 @@ description: >-
   All TME has been automatically converted to Elixor (EXOR).
 links:
 - Bitcointalk: https://bitcointalk.org/index.php?topic=2144082.msg21449690#msg21449690
-- CoinMarketCap: elixir
+- CoinMarketCap: https://coinmarketcap.com/currencies/elixir/
 - Email: mailto:elixirtoken@gmail.com
 - Github: https://github.com/elixirDev/elixir
 - Reddit: https://www.reddit.com/r/elixirtoken/

--- a/tokens/0xcb5a05bef3257613e984c17dbcf039952b6d883f.yaml
+++ b/tokens/0xcb5a05bef3257613e984c17dbcf039952b6d883f.yaml
@@ -5,7 +5,7 @@ description: >-
   A new cryptocurrency platform.
 links:
 - Bitcointalk: https://bitcointalk.org/index.php?topic=2385461
-- CoinMarketCap: sugar-exchange
+- CoinMarketCap: https://coinmarketcap.com/currencies/sugar-exchange/
 - Email: mailto:info@sugarexchange.io
 - Telegram: https://t.me/joinchat/GCd1KBFberV538lleS0kZQ
 - Twitter: https://twitter.com/Sugar_Exchange

--- a/tokens/0xcb94be6f13a1182e4a4b6140cb7bf2025d28e41b.yaml
+++ b/tokens/0xcb94be6f13a1182e4a4b6140cb7bf2025d28e41b.yaml
@@ -6,7 +6,7 @@ description: >-
 links:
 - Bitcointalk: https://bitcointalk.org/index.php?topic=1773367
 - Blog: https://medium.com/wetrust-blog
-- CoinMarketCap: trust
+- CoinMarketCap: https://coinmarketcap.com/currencies/trust/
 - Facebook: https://www.facebook.com/wetrustplatform
 - Github: https://github.com/WeTrustPlatform
 - Reddit: https://www.reddit.com/r/WeTrustPlatform/

--- a/tokens/0xcb97e65f07da24d46bcdd078ebebd7c6e6e3d750.yaml
+++ b/tokens/0xcb97e65f07da24d46bcdd078ebebd7c6e6e3d750.yaml
@@ -4,7 +4,7 @@ decimals: 8
 description: >-
   transfer assets from atomic world to byteworld
 links:
-- CoinMarketCap: bytom
+- CoinMarketCap: https://coinmarketcap.com/currencies/bytom/
 - Email: mailto:contact@bytom.io
 - Github: https://github.com/bytom
 - Twitter: https://twitter.com/Bytom_Official

--- a/tokens/0xcbcc0f036ed4788f63fc0fee32873d6a7487b908.yaml
+++ b/tokens/0xcbcc0f036ed4788f63fc0fee32873d6a7487b908.yaml
@@ -5,7 +5,7 @@ description: >-
   Humaniq is a simple and secure mobile app, delivering financial inclusion solutions globally.
 links:
 - Blog: https://blog.humaniq.co/
-- CoinMarketCap: humaniq
+- CoinMarketCap: https://coinmarketcap.com/currencies/humaniq/
 - Email: mailto:info@humaniq.com
 - Facebook: https://www.facebook.com/humaniq.co
 - Github: https://github.com/humaniq

--- a/tokens/0xcbce61316759d807c474441952ce41985bbc5a40.yaml
+++ b/tokens/0xcbce61316759d807c474441952ce41985bbc5a40.yaml
@@ -5,7 +5,7 @@ description: >-
   MOAC is an ERC-20 token that helps to fund the project of MOAC -- which will create a new blockchain
   with several advanced features such as sharding, asynchronous contract, multi-layer, subchains, etc.
 links:
-- CoinMarketCap: moac
+- CoinMarketCap: https://coinmarketcap.com/currencies/moac/
 - Email: mailto:info@moac.io
 - Github: https://github.com/MOACChain/moac-core
 - Website: http://moac.io/

--- a/tokens/0xcc34366e3842ca1bd36c1f324d15257960fcc801.yaml
+++ b/tokens/0xcc34366e3842ca1bd36c1f324d15257960fcc801.yaml
@@ -7,7 +7,7 @@ description: >-
 links:
 - Bitcointalk: https://bitcointalk.org/index.php?topic=2375768
 - Blog: https://medium.com/@bonpay
-- CoinMarketCap: bonpay
+- CoinMarketCap: https://coinmarketcap.com/currencies/bonpay/
 - Email: mailto:support@bonpay.com
 - Facebook: https://www.facebook.com/bonpaycom
 - Github: https://github.com/bonpay

--- a/tokens/0xcc4ef9eeaf656ac1a2ab886743e98e97e090ed38.yaml
+++ b/tokens/0xcc4ef9eeaf656ac1a2ab886743e98e97e090ed38.yaml
@@ -6,7 +6,7 @@ description: >-
   growth in domain names and crypto currencies. In August 2017, we raised close to $2m in an Initial Coin
   Offering.
 links:
-- CoinMarketCap: digital-developers-fund
+- CoinMarketCap: https://coinmarketcap.com/currencies/digital-developers-fund/
 - Email: mailto:info@digitaldevelopersfund.com
 - Facebook: https://www.facebook.com/pg/digitaldevelopersfund/
 - Github: https://github.com/digitaldevelopersfund/ddf

--- a/tokens/0xce5c603c78d047ef43032e96b5b785324f753a4f.yaml
+++ b/tokens/0xce5c603c78d047ef43032e96b5b785324f753a4f.yaml
@@ -4,7 +4,7 @@ decimals: 2
 description: ""
 links:
 - Blog: https://medium.com/e4row
-- CoinMarketCap: ether-for-the-rest-of-the-world
+- CoinMarketCap: https://coinmarketcap.com/currencies/ether-for-the-rest-of-the-world/
 - Github: https://github.com/liveplayergames?tab=repositories
 - Reddit: http://www.reddit.com/r/e4row
 - Slack: http://ufp.liveplayergames.com:8080/

--- a/tokens/0xced4e93198734ddaff8492d525bd258d49eb388e.yaml
+++ b/tokens/0xced4e93198734ddaff8492d525bd258d49eb388e.yaml
@@ -5,7 +5,7 @@ description: >-
   your blockchain asset experience
 links:
 - Blog: https://medium.com/eidoo
-- CoinMarketCap: eidoo
+- CoinMarketCap: https://coinmarketcap.com/currencies/eidoo/
 - Email: mailto:info@eidoo.io
 - Facebook: https://www.facebook.com/eidoocrypto/
 - Telegram: https://t.me/joinchat/AAAAAERSsZk99wFzx2v_Kw

--- a/tokens/0xcfb98637bcae43c13323eaa1731ced2b716962fd.yaml
+++ b/tokens/0xcfb98637bcae43c13323eaa1731ced2b716962fd.yaml
@@ -5,7 +5,7 @@ description: >-
   World's first Browser-based Blockchain &amp; Ecosystem
 links:
 - Blog: https://medium.com/nimiq-network
-- CoinMarketCap: nimiq
+- CoinMarketCap: https://coinmarketcap.com/currencies/nimiq/
 - Reddit: https://www.reddit.com/r/Nimiq/
 - Slack: https://nimiq-slackin.herokuapp.com/
 - Twitter: https://twitter.com/nimiqnetwork

--- a/tokens/0xd0a4b8946cb52f0661273bfbc6fd0e0c75fc6433.yaml
+++ b/tokens/0xd0a4b8946cb52f0661273bfbc6fd0e0c75fc6433.yaml
@@ -6,7 +6,7 @@ description: >-
 links:
 - Bitcointalk: https://bitcointalk.org/index.php?topic=2006999.msg21584885#msg21584885
 - Blog: https://blog.stormtoken.com/
-- CoinMarketCap: storm
+- CoinMarketCap: https://coinmarketcap.com/currencies/storm/
 - Email: mailto:info@stormtoken.com
 - Facebook: https://www.facebook.com/stormtoken
 - Github: https://github.com/StormX-Inc/crowdsale

--- a/tokens/0xd0d6d6c5fe4a677d343cc433536bb717bae167dd.yaml
+++ b/tokens/0xd0d6d6c5fe4a677d343cc433536bb717bae167dd.yaml
@@ -5,7 +5,7 @@ description: >-
   AN ETHEREUM BASED SOLUTION FOR DIGITAL ADVERTISING
 links:
 - Blog: https://medium.com/@AdChain
-- CoinMarketCap: adtoken
+- CoinMarketCap: https://coinmarketcap.com/currencies/adtoken/
 - Reddit: https://www.reddit.com/r/adChain/
 - Slack: http://slack.adchain.com/
 - Twitter: https://twitter.com/ad_chain

--- a/tokens/0xd234bf2410a0009df9c3c63b610c09738f18ccd7.yaml
+++ b/tokens/0xd234bf2410a0009df9c3c63b610c09738f18ccd7.yaml
@@ -6,7 +6,7 @@ description: >-
 links:
 - Bitcointalk: https://bitcointalk.org/index.php?topic=2339770
 - Blog: https://medium.com/@tokensnet
-- CoinMarketCap: dynamic-trading-rights
+- CoinMarketCap: https://coinmarketcap.com/currencies/dynamic-trading-rights/
 - Email: mailto:info@tokens.net
 - Facebook: https://www.facebook.com/tokens.net
 - Twitter: https://twitter.com/TokensNet

--- a/tokens/0xd26114cd6ee289accf82350c8d8487fedb8a0c07.yaml
+++ b/tokens/0xd26114cd6ee289accf82350c8d8487fedb8a0c07.yaml
@@ -14,7 +14,7 @@ description: >-
   money: as far as adoption and usage go, the system is constructed so that the best currencies will win.
 links:
 - Blog: https://blog.omisego.network/
-- CoinMarketCap: omisego
+- CoinMarketCap: https://coinmarketcap.com/currencies/omisego/
 - Email: mailto:omg@omise.co
 - Facebook: https://www.facebook.com/OmiseGO/
 - Github: https://github.com/omisego

--- a/tokens/0xd2d6158683aee4cc838067727209a0aaf4359de3.yaml
+++ b/tokens/0xd2d6158683aee4cc838067727209a0aaf4359de3.yaml
@@ -6,7 +6,7 @@ description: >-
   to receive payment for completing bounty tasks.
 links:
 - Blog: https://www.blog.bounty0x.io/
-- CoinMarketCap: bounty0x
+- CoinMarketCap: https://coinmarketcap.com/currencies/bounty0x/
 - Email: mailto:contact@bounty0x.io
 - Facebook: https://www.facebook.com/bounty0x
 - Reddit: https://www.reddit.com/r/bounty0x

--- a/tokens/0xd3c00772b24d997a812249ca637a921e81357701.yaml
+++ b/tokens/0xd3c00772b24d997a812249ca637a921e81357701.yaml
@@ -6,7 +6,7 @@ description: >-
 links:
 - Bitcointalk: https://bitcointalk.org/index.php?action=profile;u=1065611
 - Blog: http://wildcrypto.com/wild-crypto-news/
-- CoinMarketCap: wild-crypto
+- CoinMarketCap: https://coinmarketcap.com/currencies/wild-crypto/
 - Email: mailto:info@wildcrypto.com
 - Github: https://github.com/WildCryptoICO/Wild-Crypto-Token
 - Reddit: https://www.reddit.com/user/WildCrypto/

--- a/tokens/0xd49ff13661451313ca1553fd6954bd1d9b6e02b9.yaml
+++ b/tokens/0xd49ff13661451313ca1553fd6954bd1d9b6e02b9.yaml
@@ -8,7 +8,7 @@ description: >-
   30GWh of electricity for commercial and industrial customers since March 2017.
 links:
 - Blog: https://medium.com/electrifyasia
-- CoinMarketCap: https://coinmarketcap.com/currencies/electrifyasia
+- CoinMarketCap: https://coinmarketcap.com/currencies/electrifyasia/
 - Email: mailto:hello@electrify.asia
 - Facebook: https://facebook.com/electrify.asia
 - Github: https://github.com/electrifyasia/

--- a/tokens/0xd4fa1460f537bb9085d22c7bccb5dd450ef28e3a.yaml
+++ b/tokens/0xd4fa1460f537bb9085d22c7bccb5dd450ef28e3a.yaml
@@ -6,7 +6,7 @@ description: >-
   finance block by block on the blockchain.
 links:
 - Bitcointalk: https://bitcointalk.org/index.php?topic=1866936
-- CoinMarketCap: populous
+- CoinMarketCap: https://coinmarketcap.com/currencies/populous/
 - Email: mailto:info@populous.co
 - Github: https://github.com/Bitpopulous
 - Slack: https://bitpopulous.herokuapp.com/

--- a/tokens/0xd65960facb8e4a2dfcb2c2212cb2e44a02e2a57e.yaml
+++ b/tokens/0xd65960facb8e4a2dfcb2c2212cb2e44a02e2a57e.yaml
@@ -6,7 +6,7 @@ description: >-
   Your new digital cash, designed to improve efficiency and transparency for your payments and transactions.
 links:
 - Bitcointalk: https://bitcointalk.org/index.php?topic=2029634.0
-- CoinMarketCap: Soarcoin
+- CoinMarketCap: https://coinmarketcap.com/currencies/Soarcoin/
 - Email: mailto:support@soarlabs.org
 - Reddit: https://www.reddit.com/r/Soarcoin/
 - Telegram: https://t.me/joinchat/FoiRKg5U9wMPNAKz3mVflA

--- a/tokens/0xd7631787b4dcc87b1254cfd1e5ce48e96823dee8.yaml
+++ b/tokens/0xd7631787b4dcc87b1254cfd1e5ce48e96823dee8.yaml
@@ -6,7 +6,7 @@ description: >-
   network with integrated marketplace and ad platform.
 links:
 - Bitcointalk: https://bitcointalk.org/index.php?topic=2100970
-- CoinMarketCap: social
+- CoinMarketCap: https://coinmarketcap.com/currencies/social/
 - Email: mailto:support@nexus.social
 - Facebook: https://www.facebook.com/nexussocialnetwork/
 - Reddit: https://www.reddit.com/r/nexus_social/

--- a/tokens/0xd850942ef8811f2a866692a623011bde52a462c1.yaml
+++ b/tokens/0xd850942ef8811f2a866692a623011bde52a462c1.yaml
@@ -9,7 +9,7 @@ description: >-
   activities to blockchain. VeChain is creating a brand new business model, which provides 'trust service'
   to all collaboration parties across all platforms, entities, industries and consumers.
 links:
-- CoinMarketCap: vechain
+- CoinMarketCap: https://coinmarketcap.com/currencies/vechain/
 - Email: mailto:support@vechain.com
 - Github: https://github.com/vechain/
 - Slack: https://vechainofficial.slack.com/

--- a/tokens/0xd8912c10681d8b21fd3742244f44658dba12264e.yaml
+++ b/tokens/0xd8912c10681d8b21fd3742244f44658dba12264e.yaml
@@ -13,7 +13,7 @@ description: >-
   you to make in-store purchases with zero fees on conversion.
 links:
 - Blog: https://plutus.it/blog
-- CoinMarketCap: pluton
+- CoinMarketCap: https://coinmarketcap.com/currencies/pluton/
 - Email: mailto:info@plutus.it
 - Facebook: https://www.facebook.com/Plutusit/
 - Twitter: https://twitter.com/PlutusIT

--- a/tokens/0xdbfb423e9bbf16294388e07696a5120e4ceba0c5.yaml
+++ b/tokens/0xdbfb423e9bbf16294388e07696a5120e4ceba0c5.yaml
@@ -9,7 +9,7 @@ description: >-
   features onto this token.
 links:
 - Bitcointalk: https://bitcointalk.org/index.php?topic=2106405.0
-- CoinMarketCap: ethereum-dark
+- CoinMarketCap: https://coinmarketcap.com/currencies/ethereum-dark/
 - Email: mailto:support@ethereumdark.net
 - Github: https://github.com/abi2018/wz37da
 - Twitter: https://twitter.com/ethereum_dark

--- a/tokens/0xdd6c68bb32462e01705011a4e2ad1a60740f217f.yaml
+++ b/tokens/0xdd6c68bb32462e01705011a4e2ad1a60740f217f.yaml
@@ -6,7 +6,7 @@ description: >-
 links:
 - Bitcointalk: https://bitcointalk.org/index.php?topic=2041531.0
 - Blog: https://medium.com/@jacobotoll/
-- CoinMarketCap: hubii-network
+- CoinMarketCap: https://coinmarketcap.com/currencies/hubii-network/
 - Email: mailto:info@hubii.com
 - Reddit: https://www.reddit.com/r/hubiinetwork/
 - Slack: https://slack.hubii.network/

--- a/tokens/0xdd974d5c2e2928dea5f71b9825b8b646686bd200.yaml
+++ b/tokens/0xdd974d5c2e2928dea5f71b9825b8b646686bd200.yaml
@@ -5,7 +5,7 @@ description: >-
   KyberNetwork is a new system which allows the exchange and conversion of digital assets.
 links:
 - Blog: https://blog.kyber.network
-- CoinMarketCap: kyber-network
+- CoinMarketCap: https://coinmarketcap.com/currencies/kyber-network/
 - Email: mailto:hello@kyber.network
 - Github: https://github.com/KyberNetwork
 - Slack: https://kybernetwork.slack.com

--- a/tokens/0xdf6ef343350780bf8c3410bf062e0c015b1dd671.yaml
+++ b/tokens/0xdf6ef343350780bf8c3410bf062e0c015b1dd671.yaml
@@ -5,7 +5,7 @@ description: >-
   THE BRIDGE BETWEEN THE CRYPTO UNIVERSE AND THE TRADITIONAL INVESTMENT MARKET
 links:
 - Blog: https://medium.com/blackmoon-crypto
-- CoinMarketCap: blackmoon-crypto
+- CoinMarketCap: https://coinmarketcap.com/currencies/blackmoon-crypto/
 - Email: mailto:info@blackmooncrypto.com
 - Facebook: https://www.facebook.com/blackmoonfg/
 - Github: https://github.com/blackmoonfg

--- a/tokens/0xe0b7927c4af23765cb51314a0e0521a9645f0e2a.yaml
+++ b/tokens/0xe0b7927c4af23765cb51314a0e0521a9645f0e2a.yaml
@@ -11,7 +11,7 @@ description: >-
   There are 2,000,000 DGD tokens in existence.
 links:
 - Blog: https://medium.com/@digix
-- CoinMarketCap: digixdao
+- CoinMarketCap: https://coinmarketcap.com/currencies/digixdao/
 - Email: mailto:support@digix.io
 - Github: https://github.com/digixglobal
 - Reddit: https://www.reddit.com/r/digix/

--- a/tokens/0xe2e6d4be086c6938b53b22144855eef674281639.yaml
+++ b/tokens/0xe2e6d4be086c6938b53b22144855eef674281639.yaml
@@ -7,7 +7,7 @@ description: >-
   advantage of this technology and surpass their competitors.
 links:
 - Blog: https://www.medium.com/@ethlink
-- CoinMarketCap: link-platform
+- CoinMarketCap: https://coinmarketcap.com/currencies/link-platform/
 - Email: mailto:support@ethereum.link
 - Facebook: https://www.facebook.com/ethereumlink/
 - Github: https://github.com/ethlink

--- a/tokens/0xe3818504c1b32bf1557b16c238b2e01fd3149c17.yaml
+++ b/tokens/0xe3818504c1b32bf1557b16c238b2e01fd3149c17.yaml
@@ -7,7 +7,7 @@ description: >-
 links:
 - Bitcointalk: https://bitcointalk.org/index.php?topic=1986401.0
 - Blog: https://medium.com/@pullnews
-- CoinMarketCap: pillar
+- CoinMarketCap: https://coinmarketcap.com/currencies/pillar/
 - Email: mailto:info@pillarproject.io
 - Reddit: https://www.reddit.com/r/PillarProject/
 - Twitter: https://twitter.com/PillarWallet

--- a/tokens/0xe3fedaecd47aa8eab6b23227b0ee56f092c967a9.yaml
+++ b/tokens/0xe3fedaecd47aa8eab6b23227b0ee56f092c967a9.yaml
@@ -4,7 +4,7 @@ decimals: 18
 description: >-
   下一代内容价值生态圈
 links:
-- CoinMarketCap: primas
+- CoinMarketCap: https://coinmarketcap.com/currencies/primas/
 - Email: mailto:hi@primas.io
 - Facebook: https://www.facebook.com/summer.primas
 - Github: https://github.com/primasio

--- a/tokens/0xe41d2489571d322189246dafa5ebde1f4699f498.yaml
+++ b/tokens/0xe41d2489571d322189246dafa5ebde1f4699f498.yaml
@@ -5,7 +5,7 @@ description: >-
   A token trading protocol.
 links:
 - Blog: https://blog.0xproject.com/latest
-- CoinMarketCap: 0x
+- CoinMarketCap: https://coinmarketcap.com/currencies/0x/
 - Github: https://github.com/0xProject
 - Slack: https://0xproject.slack.com/
 - Twitter: https://twitter.com/0xproject

--- a/tokens/0xe469c4473af82217b30cf17b10bcdb6c8c796e75.yaml
+++ b/tokens/0xe469c4473af82217b30cf17b10bcdb6c8c796e75.yaml
@@ -4,7 +4,7 @@ decimals: 0
 description: >-
   Connecting the blockchains using crosschain gateway built on Ethereum smart contracts.
 links:
-- CoinMarketCap: exrnchain
+- CoinMarketCap: https://coinmarketcap.com/currencies/exrnchain/
 - Email: mailto:devs@exrp.io
 - Reddit: https://www.reddit.com/r/EXRNchain/
 - Telegram: https://t.me/joinchat/G9VCdRBHfrLMp9EpG7kWRQ

--- a/tokens/0xe50365f5d679cb98a1dd62d6f6e58e59321bcddf.yaml
+++ b/tokens/0xe50365f5d679cb98a1dd62d6f6e58e59321bcddf.yaml
@@ -10,7 +10,7 @@ description: >-
 links:
 - Bitcointalk: https://bitcointalk.org/index.php?topic=2083486.0
 - Blog: https://blog.latoken.com/
-- CoinMarketCap: latoken
+- CoinMarketCap: https://coinmarketcap.com/currencies/latoken/
 - Email: mailto:ico@latoken.com
 - Facebook: https://www.facebook.com/LiquidAssetToken/
 - Github: https://github.com/LAToken/smart-contract

--- a/tokens/0xe5a7c12972f3bbfe70ed29521c8949b8af6a0970.yaml
+++ b/tokens/0xe5a7c12972f3bbfe70ed29521c8949b8af6a0970.yaml
@@ -8,7 +8,7 @@ description: >-
   currently included in the DAA represent 78% of the total market capitalization of all digital assets.
 links:
 - Blog: https://medium.com/iconominet
-- CoinMarketCap: blockchain-index
+- CoinMarketCap: https://coinmarketcap.com/currencies/blockchain-index/
 - Email: mailto:support@iconomi.net
 - Facebook: https://www.facebook.com/iconomi.net
 - Reddit: https://www.reddit.com/r/ICONOMI/

--- a/tokens/0xe6923e9b56db1eed1c9f430ea761da7565e260fe.yaml
+++ b/tokens/0xe6923e9b56db1eed1c9f430ea761da7565e260fe.yaml
@@ -4,7 +4,7 @@ decimals: 2
 description: >-
   FaceCoin uses peer to peer networking and the blockchain to help your friends connect and share.
 links:
-- CoinMarketCap: facecoin
+- CoinMarketCap: https://coinmarketcap.com/currencies/facecoin/
 - Slack: https://facecoin.slack.com/join/shared_invite/MjI5NzUzNDU0Nzg2LTE1MDMzNjY5MzktZjAwNGQ0YTEzZQ
 - Twitter: https://twitter.com/facecointech
 - Website: http://facecoin.tech/ico/

--- a/tokens/0xe7775a6e9bcf904eb39da2b68c5efb4f9360e08c.yaml
+++ b/tokens/0xe7775a6e9bcf904eb39da2b68c5efb4f9360e08c.yaml
@@ -9,7 +9,7 @@ description: >-
   and tokens.
 links:
 - Blog: https://medium.com/@TaaS
-- CoinMarketCap: taas
+- CoinMarketCap: https://coinmarketcap.com/currencies/taas/
 - Facebook: https://www.facebook.com/taasfund/
 - Slack: https://taasfund.signup.team/
 - Telegram: https://t.me/taasfund

--- a/tokens/0xe8ff5c9c75deb346acac493c463c8950be03dfba.yaml
+++ b/tokens/0xe8ff5c9c75deb346acac493c463c8950be03dfba.yaml
@@ -7,7 +7,7 @@ description: >-
   experiences, gaming, and virtual dating. All decentralized on the platform designed for up to 1 billion
   users.
 links:
-- CoinMarketCap: vibe
+- CoinMarketCap: https://coinmarketcap.com/currencies/vibe/
 - Email: mailto:info@vibehub.io
 - Facebook: https://www.facebook.com/vibehubvr/
 - Reddit: https://www.reddit.com/r/VibeHub/

--- a/tokens/0xea097a2b1db00627b2fa17460ad260c016016977.yaml
+++ b/tokens/0xea097a2b1db00627b2fa17460ad260c016016977.yaml
@@ -7,7 +7,7 @@ description: >-
   these transactions with Upfire.
 links:
 - Bitcointalk: https://bitcointalk.org/index.php?topic=2223828.0
-- CoinMarketCap: upfiring
+- CoinMarketCap: https://coinmarketcap.com/currencies/upfiring/
 - Email: mailto:support@upfiring.com
 - Facebook: https://www.facebook.com/upfiring
 - Reddit: https://www.reddit.com/r/Upfiring/

--- a/tokens/0xea1f346faf023f974eb5adaf088bbcdf02d761f4.yaml
+++ b/tokens/0xea1f346faf023f974eb5adaf088bbcdf02d761f4.yaml
@@ -6,7 +6,7 @@ description: >-
   to distribute, advertise, and transfer ownership of event tickets or passes.
 links:
 - Blog: http://blog.blocktix.io/
-- CoinMarketCap: blocktix
+- CoinMarketCap: https://coinmarketcap.com/currencies/blocktix/
 - Email: mailto:info@blocktix.org
 - Github: https://github.com/blocktix
 - Reddit: https://reddit.com/r/blocktix

--- a/tokens/0xea38eaa3c86c8f9b751533ba2e562deb9acded40.yaml
+++ b/tokens/0xea38eaa3c86c8f9b751533ba2e562deb9acded40.yaml
@@ -6,7 +6,7 @@ description: >-
 links:
 - Bitcointalk: https://bitcointalk.org/index.php?topic=2005965.0
 - Blog: https://medium.com/@etherparty
-- CoinMarketCap: etherparty
+- CoinMarketCap: https://coinmarketcap.com/currencies/etherparty/
 - Email: mailto:hello@etherparty.io
 - Facebook: https://www.facebook.com/etherparty
 - Github: https://github.com/etherparty

--- a/tokens/0xeb7c20027172e5d143fb030d50f91cece2d1485d.yaml
+++ b/tokens/0xeb7c20027172e5d143fb030d50f91cece2d1485d.yaml
@@ -6,7 +6,7 @@ description: >-
 links:
 - Bitcointalk: https://bitcointalk.org/index.php?topic=2210565.0
 - Blog: https://medium.com/@eBTCFoundation
-- CoinMarketCap: ebtcnew
+- CoinMarketCap: https://coinmarketcap.com/currencies/ebtcnew/
 - Email: mailto:hello@ebitcoin.org
 - Github: https://github.com/eBTCCommunityTrustToken/eBTC
 - Reddit: https://www.reddit.com/r/eBTC/

--- a/tokens/0xee609fe292128cad03b786dbb9bc2634ccdbe7fc.yaml
+++ b/tokens/0xee609fe292128cad03b786dbb9bc2634ccdbe7fc.yaml
@@ -5,7 +5,7 @@ description: >-
   The World's First PoS Smart Contract Token
 links:
 - Bitcointalk: https://bitcointalk.org/index.php?topic=2110712.0
-- CoinMarketCap: postoken
+- CoinMarketCap: https://coinmarketcap.com/currencies/postoken/
 - Email: mailto:contact@postoken.org
 - Github: https://github.com/PoSToken
 - Slack: https://postoken.slack.com/

--- a/tokens/0xef68e7c694f40c8202821edf525de3782458639f.yaml
+++ b/tokens/0xef68e7c694f40c8202821edf525de3782458639f.yaml
@@ -8,7 +8,7 @@ description: >-
 links:
 - Bitcointalk: https://bitcointalk.org/index.php?topic=2069498.msg21584045#msg21584045
 - Blog: https://medium.com/@loopring
-- CoinMarketCap: loopring
+- CoinMarketCap: https://coinmarketcap.com/currencies/loopring/
 - Email: mailto:foundation@loopring.org
 - Github: https://github.com/loopring
 - Reddit: https://www.reddit.com/r/loopring/

--- a/tokens/0xf04a8ac553fcedb5ba99a64799155826c136b0be.yaml
+++ b/tokens/0xf04a8ac553fcedb5ba99a64799155826c136b0be.yaml
@@ -11,7 +11,7 @@ description: >-
 links:
 - Bitcointalk: https://bitcointalk.org/index.php?topic=2168758.0
 - Blog: https://medium.com/@flixxo
-- CoinMarketCap: flixxo
+- CoinMarketCap: https://coinmarketcap.com/currencies/flixxo/
 - Email: mailto:info@flixxo.com
 - Reddit: https://www.reddit.com/r/Flixxo/
 - Telegram: https://t.me/flixxo

--- a/tokens/0xf05a9382a4c3f29e2784502754293d88b835109c.yaml
+++ b/tokens/0xf05a9382a4c3f29e2784502754293d88b835109c.yaml
@@ -6,7 +6,7 @@ description: >-
 links:
 - Bitcointalk: https://bitcointalk.org/index.php?topic=2048725
 - Blog: https://blog.rexmls.com/
-- CoinMarketCap: real-estate-tokens
+- CoinMarketCap: https://coinmarketcap.com/currencies/real-estate-tokens/
 - Email: mailto:support@rexmls.com
 - Github: https://github.com/rexmls/RexToken
 - Reddit: https://www.reddit.com/r/REXMLS/

--- a/tokens/0xf0ee6b27b759c9893ce4f094b49ad28fd15a23e4.yaml
+++ b/tokens/0xf0ee6b27b759c9893ce4f094b49ad28fd15a23e4.yaml
@@ -6,7 +6,7 @@ description: >-
 links:
 - Bitcointalk: https://bitcointalk.org/index.php?topic=2052215.0
 - Blog: https://blog.enigma.co/
-- CoinMarketCap: enigma-project
+- CoinMarketCap: https://coinmarketcap.com/currencies/enigma-project/
 - Email: mailto:info@enigma.co
 - Facebook: https://www.facebook.com/enigmacatalyst/
 - Github: https://github.com/enigmampc

--- a/tokens/0xf0f8b0b8dbb1124261fc8d778e2287e3fd2cf4f5.yaml
+++ b/tokens/0xf0f8b0b8dbb1124261fc8d778e2287e3fd2cf4f5.yaml
@@ -4,7 +4,7 @@ decimals: 3
 description: >-
   bitqy is the official cryptocurrency of bitqyck, Inc.
 links:
-- CoinMarketCap: bitqy
+- CoinMarketCap: https://coinmarketcap.com/currencies/bitqy/
 - Email: mailto:mike@bitqyck.com
 - Facebook: http://www.facebook.com/bitqyofficial
 - Slack: https://bitqy.slack.com/

--- a/tokens/0xf230b790e05390fc8295f4d3f60332c93bed42e2.yaml
+++ b/tokens/0xf230b790e05390fc8295f4d3f60332c93bed42e2.yaml
@@ -10,7 +10,7 @@ description: >-
 
   Peiwo App with over 10 million users will become the first TRON-compatible entertainment APP.
 links:
-- CoinMarketCap: tron
+- CoinMarketCap: https://coinmarketcap.com/currencies/tron/
 - Email: mailto:service@tronlab.com
 - Facebook: https://www.facebook.com/TronFoundation-144555002795817/
 - Github: https://github.com/tron-network

--- a/tokens/0xf333b2ace992ac2bbd8798bf57bc65a06184afba.yaml
+++ b/tokens/0xf333b2ace992ac2bbd8798bf57bc65a06184afba.yaml
@@ -5,7 +5,7 @@ description: >-
   The world's first electronic option for high-quality sand
 links:
 - Bitcointalk: https://bitcointalk.org/index.php?topic=2049619.msg20421330#msg20421330
-- CoinMarketCap: sand-coin
+- CoinMarketCap: https://coinmarketcap.com/currencies/sand-coin/
 - Email: mailto:ico@sandcoin.io
 - Facebook: https://www.facebook.com/SandCoinICO
 - Github: https://github.com/sndtoken

--- a/tokens/0xf3db5fa2c66b7af3eb0c0b782510816cbe4813b8.yaml
+++ b/tokens/0xf3db5fa2c66b7af3eb0c0b782510816cbe4813b8.yaml
@@ -7,7 +7,7 @@ description: >-
   markets are in the palm of your hand.
 links:
 - Blog: https://blog.everex.io/
-- CoinMarketCap: everex
+- CoinMarketCap: https://coinmarketcap.com/currencies/everex/
 - Email: mailto:contact@everex.io
 - Facebook: https://www.facebook.com/everex.io
 - Github: https://github.com/EverexIO/EVXToken

--- a/tokens/0xf4134146af2d511dd5ea8cdb1c4ac88c57d60404.yaml
+++ b/tokens/0xf4134146af2d511dd5ea8cdb1c4ac88c57d60404.yaml
@@ -9,7 +9,7 @@ description: >-
 links:
 - Bitcointalk: https://bitcointalk.org/index.php?topic=1934763.0
 - Blog: http://blog.suncontract.org/
-- CoinMarketCap: suncontract
+- CoinMarketCap: https://coinmarketcap.com/currencies/suncontract/
 - Facebook: https://www.facebook.com/suncontractorg/
 - Github: https://github.com/SunContract/
 - Reddit: https://www.reddit.com/r/suncontract/

--- a/tokens/0xf433089366899d83a9f26a773d59ec7ecf30355e.yaml
+++ b/tokens/0xf433089366899d83a9f26a773d59ec7ecf30355e.yaml
@@ -6,7 +6,7 @@ description: >-
   time you spend or make a purchase. Ditch the bank and go digital.
 links:
 - Blog: https://blog.metalpay.com/
-- CoinMarketCap: metal
+- CoinMarketCap: https://coinmarketcap.com/currencies/metal/
 - Email: mailto:support@metalpay.co
 - Facebook: https://www.facebook.com/metalpaysme/
 - Slack: https://metalpay.chat/

--- a/tokens/0xf629cbd94d3791c9250152bd8dfbdf380e2a3b9c.yaml
+++ b/tokens/0xf629cbd94d3791c9250152bd8dfbdf380e2a3b9c.yaml
@@ -5,7 +5,7 @@ description: >-
   Enjin Coin is a smart cryptocurrency and virtual goods platform for gaming.
 links:
 - Blog: https://medium.com/@enjin
-- CoinMarketCap: enjin-coin
+- CoinMarketCap: https://coinmarketcap.com/currencies/enjin-coin/
 - Email: mailto:presale@enjincoin.io
 - Facebook: https://www.facebook.com/enjinsocial
 - Github: https://github.com/enjin/contracts

--- a/tokens/0xf7b098298f7c69fc14610bf71d5e02c60792894c.yaml
+++ b/tokens/0xf7b098298f7c69fc14610bf71d5e02c60792894c.yaml
@@ -11,7 +11,7 @@ description: >-
   users automatically across the platform.
 links:
 - Blog: https://medium.com/matchpool
-- CoinMarketCap: guppy
+- CoinMarketCap: https://coinmarketcap.com/currencies/guppy/
 - Facebook: https://www.facebook.com/matchpoolhq/
 - Github: https://github.com/Matchpool/
 - Reddit: https://www.reddit.com/r/Matchpool

--- a/tokens/0xf85feea2fdd81d51177f6b8f35f0e6734ce45f5f.yaml
+++ b/tokens/0xf85feea2fdd81d51177f6b8f35f0e6734ce45f5f.yaml
@@ -5,7 +5,7 @@ description: >-
   Empowering the Decentralization of Online Marketplaces
 links:
 - Blog: https://www.reddit.com/user/CyberMiles/
-- CoinMarketCap: cybermiles
+- CoinMarketCap: https://coinmarketcap.com/currencies/cybermiles/
 - Email: mailto:contact@5miles.com
 - Facebook: https://www.facebook.com/cybermiles
 - Github: https://github.com/CyberMiles

--- a/tokens/0xf8e386eda857484f5a12e4b5daa9984e06e73705.yaml
+++ b/tokens/0xf8e386eda857484f5a12e4b5daa9984e06e73705.yaml
@@ -6,7 +6,7 @@ description: >-
   indorsing the skills of others.
 links:
 - Blog: https://medium.com/joinIndorse
-- CoinMarketCap: indorse-token
+- CoinMarketCap: https://coinmarketcap.com/currencies/indorse-token/
 - Email: mailto:info@indorse.io
 - Slack: https://joinindorse.herokuapp.com/
 - Twitter: https://twitter.com/joinIndorse

--- a/tokens/0xf970b8e36e23f7fc3fd752eea86f8be8d83375a6.yaml
+++ b/tokens/0xf970b8e36e23f7fc3fd752eea86f8be8d83375a6.yaml
@@ -4,7 +4,7 @@ decimals: 18
 description: >-
   A global peer-to-peer credit network based on co-signed smart contracts.
 links:
-- CoinMarketCap: ripio-credit-network
+- CoinMarketCap: https://coinmarketcap.com/currencies/ripio-credit-network/
 - Email: mailto:info@ripiocredit.network
 - Github: https://github.com/ripio/rcn-token
 - Telegram: https://t.me/RCNtalk

--- a/tokens/0xfa05a73ffe78ef8f1a739473e462c54bae6567d9.yaml
+++ b/tokens/0xfa05a73ffe78ef8f1a739473e462c54bae6567d9.yaml
@@ -9,7 +9,7 @@ description: >-
   Augmented Reality, and more.
 links:
 - Blog: https://medium.com/lunyr
-- CoinMarketCap: lunyr
+- CoinMarketCap: https://coinmarketcap.com/currencies/lunyr/
 - Email: mailto:support@lunyr.com
 - Facebook: https://www.facebook.com/Lunyr-806275516194118
 - Github: https://github.com/lunyr

--- a/tokens/0xfca47962d45adfdfd1ab2d972315db4ce7ccf094.yaml
+++ b/tokens/0xfca47962d45adfdfd1ab2d972315db4ce7ccf094.yaml
@@ -6,7 +6,7 @@ description: >-
 links:
 - Bitcointalk: https://bitcointalk.org/index.php?topic=1963974.0
 - Blog: https://www.ixledger.com/latest/
-- CoinMarketCap: ixledger
+- CoinMarketCap: https://coinmarketcap.com/currencies/ixledger/
 - Email: mailto:info@ixledger.com
 - Facebook: https://www.facebook.com/iXledger/
 - Slack: https://ixledger.slack.com/

--- a/tokens/0xfec0cf7fe078a500abf15f1284958f22049c2c7e.yaml
+++ b/tokens/0xfec0cf7fe078a500abf15f1284958f22049c2c7e.yaml
@@ -5,7 +5,7 @@ description: >-
   The first open blockchain platform that democratises access to Fine Art
 links:
 - Blog: https://medium.com/maecenas
-- CoinMarketCap: maecenas
+- CoinMarketCap: https://coinmarketcap.com/currencies/maecenas/
 - Email: mailto:contact@maecenas.co
 - Facebook: https://www.facebook.com/maecenasart
 - Github: https://github.com/cofoundit/cfi-maecenas

--- a/tokens/0xff3519eeeea3e76f1f699ccce5e23ee0bdda41ac.yaml
+++ b/tokens/0xff3519eeeea3e76f1f699ccce5e23ee0bdda41ac.yaml
@@ -5,7 +5,7 @@ description: >-
   Blockchain Capital is a pioneer and the premier venture capital firm investing in Blockchain enabled
   technology.
 links:
-- CoinMarketCap: bcap
+- CoinMarketCap: https://coinmarketcap.com/currencies/bcap/
 - Email: http://blockchain.capital/contact/
 - Twitter: https://twitter.com/blockchaincap
 - Website: http://blockchain.capital/

--- a/tokens/0xffe8196bc259e8dedc544d935786aa4709ec3e64.yaml
+++ b/tokens/0xffe8196bc259e8dedc544d935786aa4709ec3e64.yaml
@@ -8,7 +8,7 @@ description: >-
 links:
 - Bitcointalk: https://bitcointalk.org/index.php?topic=2142867
 - Blog: https://medium.com/@hedgetoken
-- CoinMarketCap: hedge
+- CoinMarketCap: https://coinmarketcap.com/currencies/hedge/
 - Email: mailto:info@hedge-crypto.com
 - Facebook: https://www.facebook.com/hedgetoken/
 - Github: https://github.com/HedgeToken/Hedge-Token


### PR DESCRIPTION
This PR replaces old-style CMC slugs with proper URLs.