### PR TITLE
Add Wixlar WIX to ForkDelta

### DIFF
--- a/tokens/0x7ba19b7f7d106a9a1e0985397b94f38eee0b555e.yaml
+++ b/tokens/0x7ba19b7f7d106a9a1e0985397b94f38eee0b555e.yaml
@@ -1,0 +1,40 @@
+---
+addr: '0x7ba19b7f7d106a9a1e0985397b94f38eee0b555e'
+decimals: 2
+description: >-
+Wixlar is the only Digital Currency offering 12 Services to the public with 5 International Physical Offices 
+
+
+Wixlar Sponsors Major Blockchain, Charity, Sports and Fashion Events, as well as its own TV Broadcasting Channel 24/7.
+links:
+- Blog: https://wixlar.com/articles/
+- Blog2: https://wixlarcoin.blogspot.com/
+- Blog3: https://medium.com/@WixlarCoin
+- CoinGecko: https://www.coingecko.com/en/coins/wixlar
+- CoinMarketCap: https://coinmarketcap.com/currencies/wixlar/
+- Email: mailto:info@wixlar.com
+- Facebook: https://www.facebook.com/WixlarCoins/
+- Github: https://github.com/wixlar/
+- Twitter: https://twitter.com/WixlarCoin/
+- Linkedin: https://www.linkedin.com/in/WixlarCoin/
+- Youtube: https://www.youtube.com/channel/UCSXtrAk0o64u95_hWQ8F-bw/
+- Reddit: https://www.reddit.com/user/wixlarcoin
+- Tumblr: https://wixlarcoin.tumblr.com/
+- Pinterest: https://www.pinterest.com/WixlarCoin
+- BitCoinTalk: https://bitcointalk.org/index.php?topic=3245093
+- Website English: https://wixlar.com
+- Website Portuguese: https://wixlar.com/pt/
+- Website Arabic: https://wixlar.com/ar/
+- Website French: https://wixlar.com/fr/
+- Website German: https://wixlar.com/de/
+- Website Spanish: https://wixlar.com/es/
+- Website Hindi: https://wixlar.com/hi/
+- Website Vietnamese: https://wixlar.com/vi/
+- Website Russian: https://wixlar.com/ru/
+- Website Chinese: https://wixlar.com/zh/
+- Website Greek: https://wixlar.com/el/
+- Website Korean: https://wixlar.com/ko/
+- Whitepaper: https://wixlar.com/wp-content/uploads/2018/10/Wixlar-Coin-WhitePaper-v6.pdf
+- Telegram: https://t.me/wixlar
+name: Wixlar
+symbol: WIX


### PR DESCRIPTION
Token address:
https://etherscan.io/token/0x7ba19b7f7d106a9a1e0985397b94f38eee0b555e

Issuer's official website:
https://wixlar.com

Description: 
Wixlar, the only Digital Currency offering more than 12 Services to the public as well as its own TV Broadcasting Channel 24/7 on https://wixlar.com/wixlar-tv
Sponsors and participates in Major Events, more info available at https://wixlar.com/articles/

A link to the official contract address confirmation: 
Down in the page at https://wixlar.com/2017/08/15/intro-wixlar-coins/

Third-party reviews or discussion of the token, the project/product, or the token issuer:

https://irishtechnews.ie/wixlar-group-ramp-up-exchange-listings-and-blockchain-projects-for-2018/
http://www.itdaily.kr/news/articleView.html?idxno=88062
https://www.boannews.com/media/view.asp?idx=67581
https://bctech.io/marketplace/2052/wixlar-crypto-freelancing-platform/
https://ccn.tokyo/2018/06/01/wixlar-group-and-partners-are-changing-the-cryptocurrency-market-through-a-new-whole-eco-system/
https://www.xblogs.info/2018/06/wixlar-group-ramp-up-exchange-listings-and-blockchain-projects-for-2018/