### PR TITLE
Compile tokenbase data into JSON

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -17,3 +17,11 @@ cache: pip
 script:
   - git diff --name-only --diff-filter=d $TRAVIS_COMMIT_RANGE | grep tokens/ | xargs python scripts/test.py
   - git diff --name-only --diff-filter=d $TRAVIS_COMMIT_RANGE | grep tokens/ | xargs yamllint -c .yamllint
+  - python scripts/build.py
+
+deploy:
+  provider: pages
+  github-token: $GITHUB_TOKEN  # Set in travis-ci.org dashboard, marked secure
+  skip-cleanup: true
+  on:
+    branch: master

--- a/scripts/build.py
+++ b/scripts/build.py
@@ -1,20 +1,38 @@
+from glob import glob
 import json
-from os import listdir, path
 import yaml
 
+
+def read_entry(fn):
+    with open(fn) as infile:
+        return yaml.safe_load(infile)
+
+
+INDEX_KEYS = ["addr", "decimals", "name", "symbol"]
+
+
+def abridged_entry(entry):
+    return {k: entry[k] for k in INDEX_KEYS}
+
+
 def main():
-    tokens_dir = "tokens"
-    token_file_filter = lambda fname: fname.startswith("0x") and fname.endswith(".yaml")
+    files = sorted(glob("tokens/0x*.yaml"))
 
-    all_tokens = {}
-    for defn_fname in sorted(map(lambda s: s.lower(), filter(token_file_filter, listdir(tokens_dir)))):
-        with open(path.join(tokens_dir, defn_fname), encoding="utf8") as f:
-            defn = yaml.safe_load(f)
+    entries = list(read_entry(fn) for fn in files)
+    for entry in entries:
+        json_fn = "tokens/{}.json".format(entry["addr"])
+        with open(json_fn, "w") as outfile:
+            json.dump(entry, outfile, separators=(',', ':'))
 
-        all_tokens[defn["addr"]] = defn
+    with open("tokens/bundle.json", "w") as outfile:
+        json.dump(entries, outfile, separators=(',', ':'))
 
-    with open("tokens/index.json", "w", encoding="utf8") as outfile:
-        json.dump(all_tokens, outfile, separators=(',', ':'))
+    with open("tokens/index.json", "w") as outfile:
+        json.dump(
+            list(abridged_entry(entry) for entry in entries),
+            outfile,
+            separators=(',', ':'))
+
 
 if __name__ == "__main__":
     main()


### PR DESCRIPTION
## Why
We want tokenbase data to be easily reusable. While YAML is great for humans to read and edit, YAML parser performance isn't so great (most importantly, in browsers). Furthermore, getting a list of tokens present in tokenbase is slow and/or cumbersome (requires either a local working copy or accessing GitHub API).

## What
This PR adds a script & a CI build step that:
1. Builds an individual `tokens/0xADDRESS.json` file for every tokenbase entry. This file would be available on https://forkdelta.github.io/tokenbase/tokens/0xADDRESS.json.
2. Builds an index file, `tokens/index.json`, containing the contract address, decimals, native name and symbol of every token present in Tokenbase. This would be available at https://forkdelta.github.io/tokenbase/tokens/index.json.
3. Builds a "bundle" file, `tokens/bundle.js`, which contains all data for all entries in the tokenbase. This would be available at https://forkdelta.github.io/tokenbase/tokens/bundle.json.
4. Keeps the YAML available as https://forkdelta.github.io/tokenbase/tokens/0xADDRESS.yaml in sync with the master. Just in case you want a human readable / editable version of the token data.