### PR TITLE
Added XLG (Ledgerium) Token

### DIFF
--- a/0x598c9a4f069dc076984868873c01e78a905d50e6.yaml
+++ b/0x598c9a4f069dc076984868873c01e78a905d50e6.yaml
@@ -1,0 +1,14 @@
+addr: '0x598c9a4f069dc076984868873c01e78a905d50e6'
+decimals: 8
+description: >-
+  Ledgerium is disrupting the audit and trust economies by using blockchain based open ledgers. 
+  We want to take blockchain back to its first and foremost usecase of being a decentralised public ledger.
+links:
+- Email: mailto:info@ledgerium.net
+- Github: https://github.com/ledgerium
+- Twitter: https://twitter.com/ledgerium
+- Website: https://www.ledgerium.net/
+- Whitepaper: https://www.ledgerium.net/files/Ledgerium_Executive_Summary.pdf
+- Telegram: https://t.me/Ledgeriumofficial
+name: Ledgerium
+symbol: XLG


### PR DESCRIPTION
Fixes #2209
https://etherscan.io/token/0x598c9a4f069dc076984868873c01e78a905d50e6
Currently traded on ACX.io and EtherDelta under the old contract and name LGUM. This PR is for the new token which has now replaced LGUM after a swap.