### PR TITLE
Add OpenWeb Network (OWT) Token

### DIFF
--- a/tokens/0xc2494604e9dcefa2a70dcebf81e6d7be064a334e.yml
+++ b/tokens/0xc2494604e9dcefa2a70dcebf81e6d7be064a334e.yml
@@ -1,0 +1,14 @@
+---
+addr: '0xc2494604e9dcefa2a70dcebf81e6d7be064a334e'
+decimals: 18
+description: OpenWeb Network is a blockchain powered, decentralised, open source network that allows anyone to host websites to make internet open for everyone.
+links:
+- Blog: https://medium.com/openweb-network
+- Email: mailto:hello@openweb.network
+- Github: https://github.com/openweb-network
+- Telegram: https://t.me/openweb_network
+- Twitter: https://twitter.com/openweb_network
+- Website: https://openweb.network
+- Whitepaper: https://openweb.network/openweb_network_whitepaper.pdf
+name: OpenWeb Token
+symbol: OWT


### PR DESCRIPTION
Token address:
0xc2494604e9dcefa2a70dcebf81e6d7be064a334e

Issuer's official website:
https://openweb.network

TOKEN INFORMATION
Token name : OpenWeb Token
Token symbol : OWT
TOTAL SUPPLY : 1,000,000,000 OWT

Description: OpenWeb Network is a blockchain powered, decentralised, open source network that allows anyone to host websites to make internet open for everyone.

A link to the official contract address confirmation: https://etherscan.io/token/0xc2494604e9dcefa2a70dcebf81e6d7be064a334e

At least 2 links to third-party reviews or discussion of the token, the project/product, or the token issuer:

http://www.digitaljournal.com/pr/4174319
https://cryptoradar.org/openweb-network-ethereum-powered-decentralised-internet-protocol-is-live-now/
https://twitter.com/openweb_network