### PR TITLE
Update COV token to new contract

### DIFF
--- a/tokens/0xada86b1b313d1d5267e3fc0bb303f0a2b66d0ea7.yaml
+++ b/tokens/0xada86b1b313d1d5267e3fc0bb303f0a2b66d0ea7.yaml
@@ -1,0 +1,18 @@
+---
+addr: '0xada86b1b313d1d5267e3fc0bb303f0a2b66d0ea7'
+decimals: 18
+description: >-
+  COVESTING is the ultimate platform for investors and traders who are looking to utilize advanced tools
+  and technology in order achieve maximum returns in cryptocurrency markets.
+links:
+- Bitcointalk: https://bitcointalk.org/index.php?topic=2660460.0
+- Blog: https://medium.com/@Covesting
+- Email: mailto:info@covesting.io
+- Facebook: https://facebook.com/covesting
+- Github: https://github.com/covesting/covesting-io
+- Telegram: https://t.me/covesting
+- Twitter: https://twitter.com/covesting
+- Website: https://covesting.io/
+- Whitepaper: https://covesting.io/static/Covesting_White_Paper.pdf
+name: Covesting
+symbol: COV

--- a/tokens/0xe2fb6529ef566a080e6d23de0bd351311087d567.yaml
+++ b/tokens/0xe2fb6529ef566a080e6d23de0bd351311087d567.yaml
@@ -2,17 +2,8 @@
 addr: '0xe2fb6529ef566a080e6d23de0bd351311087d567'
 decimals: 18
 description: >-
-  COVESTING is the ultimate platform for investors and traders who are looking to utilize advanced tools
-  and technology in order achieve maximum returns in cryptocurrency markets.
+  This old COVESTIOG token is no longer valid. It has been repleaced by 0xada86b1b313d1d5267e3fc0bb303f0a2b66d0ea7.
 links:
-- Bitcointalk: https://bitcointalk.org/index.php?topic=2660460.0
-- Blog: https://medium.com/@Covesting
-- Email: mailto:info@covesting.io
-- Facebook: https://facebook.com/covesting
-- Github: https://github.com/covesting/covesting-io
-- Telegram: https://t.me/covesting
-- Twitter: https://twitter.com/covesting
 - Website: https://covesting.io/
-- Whitepaper: https://covesting.io/Covesting_White_Paper.pdf
-name: Covesting
+name: Covesting (old COV Token)
 symbol: COV


### PR DESCRIPTION
Since 07.10.2020 7:00am the [COV token](https://etherscan.io/address/0xe2fb6529ef566a080e6d23de0bd351311087d567) has been replaced with ne [new COV token](https://etherscan.io/token/0xada86b1b313d1d5267e3fc0bb303f0a2b66d0ea7) after a [security incident on the kucoin](https://www.kucoin.com/news/en-the-latest-updates-about-the-kucoin-security-incident).

> Due to the recent Kucoin hack, #Covesting will be performing a token swap. Tomorrow all addresses holding the $COV token will receive new tokens. Starting from 7:00am UTC and until the process completion notice all token holders are strongly advised not to move their tokens.

- https://twitter.com/covesting/status/1310103008152350725
- https://twitter.com/covesting/status/1313491990252859392
- https://www.kucoin.com/news/en-the-latest-updates-about-the-kucoin-security-incident
- https://www.kucoin.com/news/en-cov-nim-west-deposits-and-withdrawals-now-open
- https://covesting.io/cov-token